### PR TITLE
Extract HTML parsing into module with fixture tests

### DIFF
--- a/backend/src/utils/steamgifts_client.py
+++ b/backend/src/utils/steamgifts_client.py
@@ -5,19 +5,21 @@ including authentication, scraping giveaways, and entering giveaways.
 """
 
 import asyncio
-import re
 from typing import Any
 
 import httpx
 import structlog
-from bs4 import BeautifulSoup
 
 from core.exceptions import (
     SteamGiftsError,
     SteamGiftsSessionExpiredError,
 )
-from core.time import from_timestamp
+from utils import steamgifts_parser as parser
 from utils.steam_client import RateLimiter
+
+# Re-exported for backwards compatibility; the parsing logic (and these
+# word lists) live in utils.steamgifts_parser.
+from utils.steamgifts_parser import FORBIDDEN_WORDS, GOOD_WORDS  # noqa: F401
 
 logger = structlog.get_logger()
 
@@ -36,12 +38,6 @@ class SteamGiftsUnsafeError(SteamGiftsError):
         super().__init__(message, code="SG_005", details={"safety_score": safety_score})
         self.safety_score = safety_score
 
-
-# Safety detection word lists (from legacy code)
-# Words that indicate potential traps/scams
-FORBIDDEN_WORDS = (" ban", " fake", " bot", " not enter", " don't enter", " do not enter")
-# Words that look similar but are innocent (to avoid false positives)
-GOOD_WORDS = (" bank", " banan", " both", " band", " banner", " bang")
 
 
 class SteamGiftsClient:
@@ -272,33 +268,14 @@ class SteamGiftsClient:
                 details={"status_code": response.status_code},
             )
 
-        soup = BeautifulSoup(response.text, "html.parser")
-
-        # XSRF token is in a hidden input or data attribute
-        token_input = soup.find("input", {"name": "xsrf_token"})
-        if token_input:
-            value = token_input.get("value")
-            self.xsrf_token = str(value) if value else None
-            return
-
-        # Try to find it in data-form attribute
-        form_element = soup.find(lambda tag: tag.has_attr("data-form"))
-        if form_element:
-            # Token might be in a JSON-encoded string
-            import json
-            try:
-                form_data = json.loads(str(form_element["data-form"]))
-                if "xsrf_token" in form_data:
-                    self.xsrf_token = form_data["xsrf_token"]
-                    return
-            except (json.JSONDecodeError, KeyError):
-                pass
-
-        raise SteamGiftsSessionExpiredError(
-            "Could not extract XSRF token - session expired or invalid",
-            code="SG_004",
-            details={"reason": "xsrf_token_not_found"},
-        )
+        token = parser.extract_xsrf_token(response.text)
+        if token is None:
+            raise SteamGiftsSessionExpiredError(
+                "Could not extract XSRF token - session expired or invalid",
+                code="SG_004",
+                details={"reason": "xsrf_token_not_found"},
+            )
+        self.xsrf_token = token
 
     async def get_user_points(self) -> int:
         """
@@ -326,28 +303,19 @@ class SteamGiftsClient:
                 details={"status_code": response.status_code},
             )
 
-        soup = BeautifulSoup(response.text, "html.parser")
+        try:
+            points = parser.parse_user_points(response.text)
+        except ValueError as e:
+            raise SteamGiftsError(str(e), code="SG_002", details={})
 
-        # Points are in nav__points element
-        points_element = soup.find("span", class_="nav__points")
-        if not points_element:
+        if points is None:
             raise SteamGiftsSessionExpiredError(
                 "Could not find points - session expired or invalid",
                 code="SG_004",
                 details={"reason": "points_element_not_found"},
             )
 
-        # Extract number from text like "123P"
-        points_text = points_element.text.strip()
-        match = re.search(r"(\d+)", points_text)
-        if not match:
-            raise SteamGiftsError(
-                f"Could not parse points: {points_text}",
-                code="SG_002",
-                details={"points_text": points_text},
-            )
-
-        return int(match.group(1))
+        return points
 
     async def get_user_info(self) -> dict[str, Any]:
         """
@@ -375,69 +343,19 @@ class SteamGiftsClient:
                 details={"status_code": response.status_code},
             )
 
-        soup = BeautifulSoup(response.text, "html.parser")
+        try:
+            points = parser.parse_user_points(response.text)
+        except ValueError as e:
+            raise SteamGiftsError(str(e), code="SG_002", details={})
 
-        # Points are in nav__points element
-        points_element = soup.find("span", class_="nav__points")
-        if not points_element:
+        if points is None:
             raise SteamGiftsSessionExpiredError(
                 "Could not find points - session expired or invalid",
                 code="SG_004",
                 details={"reason": "points_element_not_found"},
             )
 
-        # Extract number from text
-        points_text = points_element.text.strip()
-        match = re.search(r"(\d+)", points_text)
-        if not match:
-            raise SteamGiftsError(
-                f"Could not parse points: {points_text}",
-                code="SG_002",
-                details={"points_text": points_text},
-            )
-        points = int(match.group(1))
-
-        # Username is in a link to /user/<username>
-        # The logged-in user's profile link is typically in the nav area
-        username = None
-
-        # Method 1: Look for nav__avatar-inner-wrap (user avatar link)
-        avatar_link = soup.find("a", class_="nav__avatar-inner-wrap")
-        if avatar_link:
-            href = str(avatar_link.get("href", "") or "")
-            username_match = re.search(r"/user/([^/]+)", href)
-            if username_match:
-                username = username_match.group(1)
-
-        # Method 2: Look for the user's profile link in the nav area
-        # This is typically the first /user/ link that appears in navigation
-        if not username:
-            # Find nav__button-container which contains the user dropdown
-            nav_container = soup.find("div", class_="nav__button-container")
-            if nav_container:
-                user_link = nav_container.find("a", href=re.compile(r"^/user/"))
-                if user_link:
-                    href = str(user_link.get("href", "") or "")
-                    username_match = re.search(r"/user/([^/]+)", href)
-                    if username_match:
-                        username = username_match.group(1)
-
-        # Method 3: Look for any /user/ link in the header/nav that points to current user
-        # The logged-in user's link is usually near the top and associated with points
-        if not username:
-            # Find the nav__points element's parent and look for nearby user link
-            if points_element:
-                parent = points_element.parent
-                while parent and parent.name != "nav":
-                    user_link = parent.find("a", href=re.compile(r"^/user/"))
-                    if user_link:
-                        href = str(user_link.get("href", "") or "")
-                        username_match = re.search(r"/user/([^/]+)", href)
-                        if username_match:
-                            username = username_match.group(1)
-                            break
-                    parent = parent.parent
-
+        username = parser.parse_username(response.text)
         if not username:
             raise SteamGiftsSessionExpiredError(
                 "Could not find username - session expired or invalid",
@@ -523,119 +441,9 @@ class SteamGiftsClient:
                 details={"status_code": response.status_code},
             )
 
-        soup = BeautifulSoup(response.text, "html.parser")
-
-        giveaways = []
-        giveaway_elements = soup.find_all("div", class_="giveaway__row-inner-wrap")
-
-        for element in giveaway_elements:
-            try:
-                # Skip pinned/advertisement giveaways ("Featured" section at the
-                # top of wishlist pages). The container class has changed over
-                # time (pinned-giveaways__inner-wrap, then pinned-giveaways),
-                # so match any pinned-giveaways* ancestor.
-                if element.find_parent("div", class_=re.compile(r"^pinned-giveaways")):
-                    continue
-
-                giveaway = self._parse_giveaway_element(element)
-                if giveaway:
-                    # Mark wishlist giveaways
-                    giveaway["is_wishlist"] = giveaway_type == "wishlist"
-                    giveaways.append(giveaway)
-            except Exception as e:
-                # Log error but continue parsing other giveaways
-                logger.warning("giveaway_parse_failed", error=str(e))
-                continue
-
-        return giveaways
-
-    def _parse_giveaway_element(self, element: Any) -> dict[str, Any] | None:
-        """
-        Parse giveaway data from HTML element.
-
-        Args:
-            element: BeautifulSoup element containing giveaway data
-
-        Returns:
-            Dictionary with giveaway data, or None if parsing fails
-        """
-        # Extract giveaway code from link
-        link = element.find("a", class_="giveaway__heading__name")
-        if not link:
-            return None
-
-        href = link.get("href", "")
-        code_match = re.search(r"/giveaway/([^/]+)/", href)
-        if not code_match:
-            return None
-
-        code = code_match.group(1)
-        game_name = link.text.strip()
-
-        # Extract points
-        points_element = element.find("span", class_="giveaway__heading__thin")
-        price = 0
-        if points_element:
-            points_text = points_element.text.strip()
-            match = re.search(r"\((\d+)P\)", points_text)
-            if match:
-                price = int(match.group(1))
-
-        # Extract copies
-        copies = 1
-        copies_element = element.find("span", class_="giveaway__heading__thin")
-        if copies_element:
-            copies_text = copies_element.text.strip()
-            match = re.search(r"(\d+)\s+Copies", copies_text)
-            if match:
-                copies = int(match.group(1))
-
-        # Extract entries count
-        entries = 0
-        entries_element = element.find("span", class_="giveaway__links")
-        if entries_element:
-            entries_text = entries_element.text.strip()
-            match = re.search(r"(\d+)\s+entries", entries_text)
-            if match:
-                entries = int(match.group(1))
-
-        # Extract end time
-        time_element = element.find("span", {"data-timestamp": True})
-        end_time = None
-        if time_element:
-            timestamp = int(time_element["data-timestamp"])
-            end_time = from_timestamp(timestamp)
-
-        # Extract thumbnail URL
-        thumbnail_url = None
-        img_element = element.find("a", class_="giveaway_image_thumbnail")
-        if img_element:
-            style = img_element.get("style", "")
-            url_match = re.search(r"url\((.*?)\)", style)
-            if url_match:
-                thumbnail_url = url_match.group(1).strip("'\"")
-
-        # Try to extract game ID from thumbnail URL
-        game_id = None
-        if thumbnail_url:
-            id_match = re.search(r"/apps/(\d+)/", thumbnail_url)
-            if id_match:
-                game_id = int(id_match.group(1))
-
-        # Check if already entered (has "is-faded" class)
-        is_entered = "is-faded" in element.get("class", [])
-
-        return {
-            "code": code,
-            "game_name": game_name,
-            "price": price,
-            "copies": copies,
-            "entries": entries,
-            "end_time": end_time,
-            "thumbnail_url": thumbnail_url,
-            "game_id": game_id,
-            "is_entered": is_entered,
-        }
+        return parser.parse_giveaway_list(
+            response.text, mark_wishlist=giveaway_type == "wishlist"
+        )
 
     async def enter_giveaway(self, giveaway_code: str) -> bool:
         """
@@ -731,18 +539,8 @@ class SteamGiftsClient:
                 details={"status_code": response.status_code},
             )
 
-        soup = BeautifulSoup(response.text, "html.parser")
-
-        # Parse giveaway details from page
-        # This is a simplified version - real implementation would extract more details
-        heading = soup.find("a", class_="giveaway__heading__name")
-        game_name = heading.text.strip() if heading else "Unknown"
-
-        return {
-            "code": giveaway_code,
-            "game_name": game_name,
-            # Add more fields as needed
-        }
+        details = parser.parse_giveaway_details(response.text)
+        return {"code": giveaway_code, **details}
 
     async def check_if_entered(self, giveaway_code: str) -> bool:
         """
@@ -801,90 +599,7 @@ class SteamGiftsClient:
                 details={"status_code": response.status_code},
             )
 
-        soup = BeautifulSoup(response.text, "html.parser")
-
-        won_giveaways = []
-
-        # Won giveaways are in table rows
-        table_rows = soup.find_all("div", class_="table__row-inner-wrap")
-
-        for row in table_rows:
-            try:
-                won = self._parse_won_giveaway_row(row)
-                if won:
-                    won_giveaways.append(won)
-            except Exception as e:
-                logger.warning("won_giveaway_parse_failed", error=str(e))
-                continue
-
-        return won_giveaways
-
-    def _parse_won_giveaway_row(self, row: Any) -> dict[str, Any] | None:
-        """
-        Parse a won giveaway row from the /giveaways/won page.
-
-        Args:
-            row: BeautifulSoup element containing won giveaway data
-
-        Returns:
-            Dictionary with won giveaway data, or None if parsing fails
-        """
-        # Find the game name and giveaway link
-        heading = row.find("a", class_="table__column__heading")
-        if not heading:
-            return None
-
-        game_name = heading.text.strip()
-        href = heading.get("href", "")
-
-        # Extract giveaway code from URL
-        code_match = re.search(r"/giveaway/([^/]+)/", href)
-        if not code_match:
-            return None
-
-        code = code_match.group(1)
-
-        # Try to extract game ID from thumbnail image URL
-        game_id = None
-        thumbnail = row.find("a", class_="table_image_thumbnail")
-        if thumbnail:
-            style = thumbnail.get("style", "")
-            id_match = re.search(r"/apps/(\d+)/", style)
-            if id_match:
-                game_id = int(id_match.group(1))
-
-        # Check if gift was received (look for icon-green class in feedback div)
-        received = False
-        feedback_divs = row.find_all("div", class_="table__column--gift-feedback")
-        for feedback in feedback_divs:
-            if feedback.find("i", class_="icon-green"):
-                received = True
-                break
-
-        # Try to get the end time from timestamp
-        won_at = None
-        time_element = row.find("span", {"data-timestamp": True})
-        if time_element:
-            try:
-                timestamp = int(time_element["data-timestamp"])
-                won_at = from_timestamp(timestamp)
-            except (ValueError, KeyError):
-                pass
-
-        # Extract Steam key if visible
-        steam_key = None
-        key_element = row.find("i", {"data-clipboard-text": True})
-        if key_element:
-            steam_key = key_element.get("data-clipboard-text")
-
-        return {
-            "code": code,
-            "game_name": game_name,
-            "game_id": game_id,
-            "won_at": won_at,
-            "received": received,
-            "steam_key": steam_key,
-        }
+        return parser.parse_won_giveaways(response.text)
 
     async def get_entered_giveaways(self, page: int = 1) -> list[dict[str, Any]]:
         """
@@ -925,180 +640,15 @@ class SteamGiftsClient:
                 details={"status_code": response.status_code},
             )
 
-        soup = BeautifulSoup(response.text, "html.parser")
-
-        entered_giveaways = []
-
-        # Entered giveaways are in table rows
-        table_rows = soup.find_all("div", class_="table__row-inner-wrap")
-
-        for row in table_rows:
-            try:
-                entered = self._parse_entered_giveaway_row(row)
-                if entered:
-                    entered_giveaways.append(entered)
-            except Exception as e:
-                logger.warning("entered_giveaway_parse_failed", error=str(e))
-                continue
-
-        return entered_giveaways
-
-    def _parse_entered_giveaway_row(self, row: Any) -> dict[str, Any] | None:
-        """
-        Parse an entered giveaway row from the /giveaways/entered page.
-
-        Args:
-            row: BeautifulSoup element containing entered giveaway data
-
-        Returns:
-            Dictionary with entered giveaway data, or None if parsing fails
-        """
-        # Find the game name and giveaway link
-        heading = row.find("a", class_="table__column__heading")
-        if not heading:
-            return None
-
-        # Game name is the text without the price span
-        game_name_parts = []
-        for child in heading.children:
-            if isinstance(child, str):
-                game_name_parts.append(child.strip())
-            elif child.name != "span":
-                game_name_parts.append(child.text.strip())
-        game_name = " ".join(game_name_parts).strip()
-
-        href = heading.get("href", "")
-
-        # Extract giveaway code from URL
-        code_match = re.search(r"/giveaway/([^/]+)/", href)
-        if not code_match:
-            return None
-
-        code = code_match.group(1)
-
-        # Extract price from the span inside heading
-        price = 0
-        price_span = heading.find("span", class_="is-faded")
-        if price_span:
-            price_match = re.search(r"\((\d+)P\)", price_span.text)
-            if price_match:
-                price = int(price_match.group(1))
-
-        # Try to extract game ID from thumbnail image URL
-        game_id = None
-        thumbnail = row.find("a", class_="table_image_thumbnail")
-        if thumbnail:
-            style = thumbnail.get("style", "")
-            id_match = re.search(r"/apps/(\d+)/", style)
-            if id_match:
-                game_id = int(id_match.group(1))
-
-        # Get entries count (usually in a text-center column)
-        entries = 0
-        columns = row.find_all("div", class_="table__column--width-small")
-        if columns:
-            # First column is usually entries count
-            entries_text = columns[0].text.strip().replace(",", "")
-            if entries_text.isdigit():
-                entries = int(entries_text)
-
-        # Get end time from the "remaining" text
-        end_time = None
-        # Look for timestamp in the fill column
-        fill_col = row.find("div", class_="table__column--width-fill")
-        if fill_col:
-            time_element = fill_col.find("span", {"data-timestamp": True})
-            if time_element:
-                try:
-                    timestamp = int(time_element["data-timestamp"])
-                    end_time = from_timestamp(timestamp)
-                except (ValueError, KeyError):
-                    pass
-
-        # Get entered_at timestamp (second timestamp in the row)
-        entered_at = None
-        if len(columns) >= 2:
-            time_element = columns[1].find("span", {"data-timestamp": True})
-            if time_element:
-                try:
-                    timestamp = int(time_element["data-timestamp"])
-                    entered_at = from_timestamp(timestamp)
-                except (ValueError, KeyError):
-                    pass
-
-        return {
-            "code": code,
-            "game_name": game_name,
-            "game_id": game_id,
-            "price": price,
-            "entries": entries,
-            "end_time": end_time,
-            "entered_at": entered_at,
-        }
+        return parser.parse_entered_giveaways(response.text)
 
     def check_page_safety(self, html_content: str) -> dict[str, Any]:
+        """Analyze giveaway page text for trap indicators.
+
+        Thin wrapper around :func:`utils.steamgifts_parser.check_page_safety`
+        (see it for the result shape).
         """
-        Check if a giveaway page contains suspicious content.
-
-        Analyzes the page text for forbidden words that might indicate
-        a trap giveaway (e.g., "don't enter", "ban", "fake").
-
-        Args:
-            html_content: Raw HTML content of the giveaway page
-
-        Returns:
-            Dictionary with safety check results:
-                - is_safe: True if page appears safe
-                - safety_score: Score from 0-100 (higher = safer)
-                - bad_count: Number of bad words found
-                - good_count: Number of good words found (false positives)
-                - details: List of found bad words
-
-        Example:
-            >>> result = client.check_page_safety(html)
-            >>> if not result['is_safe']:
-            ...     print(f"Warning: {result['details']}")
-        """
-        text_lower = html_content.lower()
-
-        bad_count = 0
-        good_count = 0
-        found_bad_words = []
-
-        # Count forbidden words
-        for bad_word in FORBIDDEN_WORDS:
-            count = text_lower.count(bad_word.lower())
-            if count > 0:
-                bad_count += count
-                found_bad_words.append(bad_word.strip())
-
-        # Count good words (false positive indicators)
-        if bad_count > 0:
-            for good_word in GOOD_WORDS:
-                good_count += text_lower.count(good_word.lower())
-
-        # Calculate safety score
-        # Net bad = bad words minus false positives
-        net_bad = max(0, bad_count - good_count)
-
-        if net_bad == 0:
-            safety_score = 100
-            is_safe = True
-        elif net_bad <= 2:
-            safety_score = 50
-            is_safe = True  # Borderline, but allow
-        else:
-            safety_score = max(0, 100 - (net_bad * 20))
-            is_safe = False
-
-        return {
-            "is_safe": is_safe,
-            "safety_score": safety_score,
-            "bad_count": bad_count,
-            "good_count": good_count,
-            "net_bad": net_bad,
-            "details": found_bad_words,
-        }
+        return parser.check_page_safety(html_content)
 
     async def check_giveaway_safety(self, giveaway_code: str) -> dict[str, Any]:
         """
@@ -1211,16 +761,7 @@ class SteamGiftsClient:
         if response.status_code != 200:
             return None
 
-        soup = BeautifulSoup(response.text, "html.parser")
-
-        # Game ID is in data-game-id attribute of the featured wrapper
-        featured = soup.find("div", class_="featured__outer-wrap")
-        if featured:
-            game_id = featured.get("data-game-id")
-            if game_id:
-                return int(str(game_id))
-
-        return None
+        return parser.parse_giveaway_game_id(response.text)
 
     async def post_comment(
         self, giveaway_code: str, comment_text: str = "Thanks!"

--- a/backend/src/utils/steamgifts_parser.py
+++ b/backend/src/utils/steamgifts_parser.py
@@ -1,0 +1,481 @@
+"""Pure HTML parsers for SteamGifts pages.
+
+Every function here takes HTML (or a BeautifulSoup element) and returns plain
+data — no HTTP, no sessions, no app exceptions. This keeps the scraping logic
+testable against saved page fixtures (see tests/unit/test_steamgifts_parser.py
+and tests/fixtures/), so a SteamGifts markup change shows up as a failing
+fixture test instead of silently wrong data.
+
+Error convention: "not found" is ``None`` (or an empty list); genuinely
+malformed content raises ``ValueError``. The HTTP client maps those onto its
+session/scrape exceptions.
+"""
+
+import json
+import re
+from typing import Any
+
+import structlog
+from bs4 import BeautifulSoup
+
+from core.time import from_timestamp
+
+logger = structlog.get_logger()
+
+# Safety detection word lists (from legacy code)
+# Words that indicate potential traps/scams
+FORBIDDEN_WORDS = (" ban", " fake", " bot", " not enter", " don't enter", " do not enter")
+# Words that look similar but are innocent (to avoid false positives)
+GOOD_WORDS = (" bank", " banan", " both", " band", " banner", " bang")
+
+
+def extract_xsrf_token(html: str) -> str | None:
+    """Extract the XSRF token embedded in any authenticated page, or None."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    # XSRF token is in a hidden input or data attribute
+    token_input = soup.find("input", {"name": "xsrf_token"})
+    if token_input:
+        value = token_input.get("value")
+        return str(value) if value else None
+
+    # Try to find it in data-form attribute (JSON-encoded)
+    form_element = soup.find(lambda tag: tag.has_attr("data-form"))
+    if form_element:
+        try:
+            form_data = json.loads(str(form_element["data-form"]))
+            if "xsrf_token" in form_data:
+                return str(form_data["xsrf_token"])
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    return None
+
+
+def parse_user_points(html: str) -> int | None:
+    """Points balance from the nav bar; None when the element is missing
+    (session expired). Raises ValueError when the element text is malformed."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    points_element = soup.find("span", class_="nav__points")
+    if not points_element:
+        return None
+
+    points_text = points_element.text.strip()
+    match = re.search(r"(\d+)", points_text)
+    if not match:
+        raise ValueError(f"Could not parse points: {points_text}")
+
+    return int(match.group(1))
+
+
+def parse_username(html: str) -> str | None:
+    """Logged-in username from the nav area, or None when not present."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Method 1: the user avatar link
+    avatar_link = soup.find("a", class_="nav__avatar-inner-wrap")
+    if avatar_link:
+        href = str(avatar_link.get("href", "") or "")
+        username_match = re.search(r"/user/([^/]+)", href)
+        if username_match:
+            return username_match.group(1)
+
+    # Method 2: the user dropdown in the nav button container
+    nav_container = soup.find("div", class_="nav__button-container")
+    if nav_container:
+        user_link = nav_container.find("a", href=re.compile(r"^/user/"))
+        if user_link:
+            href = str(user_link.get("href", "") or "")
+            username_match = re.search(r"/user/([^/]+)", href)
+            if username_match:
+                return username_match.group(1)
+
+    # Method 3: any /user/ link near the points element
+    points_element = soup.find("span", class_="nav__points")
+    if points_element:
+        parent = points_element.parent
+        while parent and parent.name != "nav":
+            user_link = parent.find("a", href=re.compile(r"^/user/"))
+            if user_link:
+                href = str(user_link.get("href", "") or "")
+                username_match = re.search(r"/user/([^/]+)", href)
+                if username_match:
+                    return username_match.group(1)
+            parent = parent.parent
+
+    return None
+
+
+def parse_giveaway_list(html: str, mark_wishlist: bool = False) -> list[dict[str, Any]]:
+    """Parse a giveaway search/listing page into giveaway dicts.
+
+    Skips pinned/"Featured" advertisement giveaways. Rows that fail to parse
+    are logged and dropped rather than failing the whole page.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    giveaways = []
+    giveaway_elements = soup.find_all("div", class_="giveaway__row-inner-wrap")
+
+    for element in giveaway_elements:
+        try:
+            # Skip pinned/advertisement giveaways ("Featured" section at the
+            # top of wishlist pages). The container class has changed over
+            # time (pinned-giveaways__inner-wrap, then pinned-giveaways),
+            # so match any pinned-giveaways* ancestor.
+            if element.find_parent("div", class_=re.compile(r"^pinned-giveaways")):
+                continue
+
+            giveaway = parse_giveaway_element(element)
+            if giveaway:
+                giveaway["is_wishlist"] = mark_wishlist
+                giveaways.append(giveaway)
+        except Exception as e:
+            # Log error but continue parsing other giveaways
+            logger.warning("giveaway_parse_failed", error=str(e))
+            continue
+
+    return giveaways
+
+
+def parse_giveaway_element(element: Any) -> dict[str, Any] | None:
+    """Parse one giveaway row element, or None if it has no usable link."""
+    # Extract giveaway code from link
+    link = element.find("a", class_="giveaway__heading__name")
+    if not link:
+        return None
+
+    href = link.get("href", "")
+    code_match = re.search(r"/giveaway/([^/]+)/", href)
+    if not code_match:
+        return None
+
+    code = code_match.group(1)
+    game_name = link.text.strip()
+
+    # Extract points
+    points_element = element.find("span", class_="giveaway__heading__thin")
+    price = 0
+    if points_element:
+        points_text = points_element.text.strip()
+        match = re.search(r"\((\d+)P\)", points_text)
+        if match:
+            price = int(match.group(1))
+
+    # Extract copies
+    copies = 1
+    copies_element = element.find("span", class_="giveaway__heading__thin")
+    if copies_element:
+        copies_text = copies_element.text.strip()
+        match = re.search(r"(\d+)\s+Copies", copies_text)
+        if match:
+            copies = int(match.group(1))
+
+    # Extract entries count
+    entries = 0
+    entries_element = element.find("span", class_="giveaway__links")
+    if entries_element:
+        entries_text = entries_element.text.strip()
+        match = re.search(r"(\d+)\s+entries", entries_text)
+        if match:
+            entries = int(match.group(1))
+
+    # Extract end time
+    time_element = element.find("span", {"data-timestamp": True})
+    end_time = None
+    if time_element:
+        timestamp = int(time_element["data-timestamp"])
+        end_time = from_timestamp(timestamp)
+
+    # Extract thumbnail URL
+    thumbnail_url = None
+    img_element = element.find("a", class_="giveaway_image_thumbnail")
+    if img_element:
+        style = img_element.get("style", "")
+        url_match = re.search(r"url\((.*?)\)", style)
+        if url_match:
+            thumbnail_url = url_match.group(1).strip("'\"")
+
+    # Try to extract game ID from thumbnail URL
+    game_id = None
+    if thumbnail_url:
+        id_match = re.search(r"/apps/(\d+)/", thumbnail_url)
+        if id_match:
+            game_id = int(id_match.group(1))
+
+    # Check if already entered (has "is-faded" class)
+    is_entered = "is-faded" in element.get("class", [])
+
+    return {
+        "code": code,
+        "game_name": game_name,
+        "price": price,
+        "copies": copies,
+        "entries": entries,
+        "end_time": end_time,
+        "thumbnail_url": thumbnail_url,
+        "game_id": game_id,
+        "is_entered": is_entered,
+    }
+
+
+def parse_giveaway_details(html: str) -> dict[str, Any]:
+    """Parse a single giveaway page into a details dict (game_name only for now)."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    heading = soup.find("a", class_="giveaway__heading__name")
+    game_name = heading.text.strip() if heading else "Unknown"
+
+    return {"game_name": game_name}
+
+
+def parse_won_giveaways(html: str) -> list[dict[str, Any]]:
+    """Parse the /giveaways/won page into won-giveaway dicts."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    won_giveaways = []
+    table_rows = soup.find_all("div", class_="table__row-inner-wrap")
+
+    for row in table_rows:
+        try:
+            won = parse_won_giveaway_row(row)
+            if won:
+                won_giveaways.append(won)
+        except Exception as e:
+            logger.warning("won_giveaway_parse_failed", error=str(e))
+            continue
+
+    return won_giveaways
+
+
+def parse_won_giveaway_row(row: Any) -> dict[str, Any] | None:
+    """Parse one row of the /giveaways/won page, or None if unusable."""
+    # Find the game name and giveaway link
+    heading = row.find("a", class_="table__column__heading")
+    if not heading:
+        return None
+
+    game_name = heading.text.strip()
+    href = heading.get("href", "")
+
+    code_match = re.search(r"/giveaway/([^/]+)/", href)
+    if not code_match:
+        return None
+
+    code = code_match.group(1)
+
+    # Try to extract game ID from thumbnail image URL
+    game_id = None
+    thumbnail = row.find("a", class_="table_image_thumbnail")
+    if thumbnail:
+        style = thumbnail.get("style", "")
+        id_match = re.search(r"/apps/(\d+)/", style)
+        if id_match:
+            game_id = int(id_match.group(1))
+
+    # Check if gift was received (look for icon-green class in feedback div)
+    received = False
+    feedback_divs = row.find_all("div", class_="table__column--gift-feedback")
+    for feedback in feedback_divs:
+        if feedback.find("i", class_="icon-green"):
+            received = True
+            break
+
+    # Try to get the end time from timestamp
+    won_at = None
+    time_element = row.find("span", {"data-timestamp": True})
+    if time_element:
+        try:
+            timestamp = int(time_element["data-timestamp"])
+            won_at = from_timestamp(timestamp)
+        except (ValueError, KeyError):
+            pass
+
+    # Extract Steam key if visible
+    steam_key = None
+    key_element = row.find("i", {"data-clipboard-text": True})
+    if key_element:
+        steam_key = key_element.get("data-clipboard-text")
+
+    return {
+        "code": code,
+        "game_name": game_name,
+        "game_id": game_id,
+        "won_at": won_at,
+        "received": received,
+        "steam_key": steam_key,
+    }
+
+
+def parse_entered_giveaways(html: str) -> list[dict[str, Any]]:
+    """Parse the /giveaways/entered page into entered-giveaway dicts."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    entered_giveaways = []
+    table_rows = soup.find_all("div", class_="table__row-inner-wrap")
+
+    for row in table_rows:
+        try:
+            entered = parse_entered_giveaway_row(row)
+            if entered:
+                entered_giveaways.append(entered)
+        except Exception as e:
+            logger.warning("entered_giveaway_parse_failed", error=str(e))
+            continue
+
+    return entered_giveaways
+
+
+def parse_entered_giveaway_row(row: Any) -> dict[str, Any] | None:
+    """Parse one row of the /giveaways/entered page, or None if unusable."""
+    # Find the game name and giveaway link
+    heading = row.find("a", class_="table__column__heading")
+    if not heading:
+        return None
+
+    # Game name is the text without the price span
+    game_name_parts = []
+    for child in heading.children:
+        if isinstance(child, str):
+            game_name_parts.append(child.strip())
+        elif child.name != "span":
+            game_name_parts.append(child.text.strip())
+    game_name = " ".join(game_name_parts).strip()
+
+    href = heading.get("href", "")
+
+    code_match = re.search(r"/giveaway/([^/]+)/", href)
+    if not code_match:
+        return None
+
+    code = code_match.group(1)
+
+    # Extract price from the span inside heading
+    price = 0
+    price_span = heading.find("span", class_="is-faded")
+    if price_span:
+        price_match = re.search(r"\((\d+)P\)", price_span.text)
+        if price_match:
+            price = int(price_match.group(1))
+
+    # Try to extract game ID from thumbnail image URL
+    game_id = None
+    thumbnail = row.find("a", class_="table_image_thumbnail")
+    if thumbnail:
+        style = thumbnail.get("style", "")
+        id_match = re.search(r"/apps/(\d+)/", style)
+        if id_match:
+            game_id = int(id_match.group(1))
+
+    # Get entries count (usually in a text-center column)
+    entries = 0
+    columns = row.find_all("div", class_="table__column--width-small")
+    if columns:
+        # First column is usually entries count
+        entries_text = columns[0].text.strip().replace(",", "")
+        if entries_text.isdigit():
+            entries = int(entries_text)
+
+    # Get end time from the "remaining" text
+    end_time = None
+    fill_col = row.find("div", class_="table__column--width-fill")
+    if fill_col:
+        time_element = fill_col.find("span", {"data-timestamp": True})
+        if time_element:
+            try:
+                timestamp = int(time_element["data-timestamp"])
+                end_time = from_timestamp(timestamp)
+            except (ValueError, KeyError):
+                pass
+
+    # Get entered_at timestamp (second timestamp in the row)
+    entered_at = None
+    if len(columns) >= 2:
+        time_element = columns[1].find("span", {"data-timestamp": True})
+        if time_element:
+            try:
+                timestamp = int(time_element["data-timestamp"])
+                entered_at = from_timestamp(timestamp)
+            except (ValueError, KeyError):
+                pass
+
+    return {
+        "code": code,
+        "game_name": game_name,
+        "game_id": game_id,
+        "price": price,
+        "entries": entries,
+        "end_time": end_time,
+        "entered_at": entered_at,
+    }
+
+
+def parse_giveaway_game_id(html: str) -> int | None:
+    """Steam game id from a giveaway page's featured wrapper, or None."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    featured = soup.find("div", class_="featured__outer-wrap")
+    if featured:
+        game_id = featured.get("data-game-id")
+        if game_id:
+            return int(str(game_id))
+
+    return None
+
+
+def check_page_safety(html_content: str) -> dict[str, Any]:
+    """
+    Check if a giveaway page contains suspicious content.
+
+    Analyzes the page text for forbidden words that might indicate
+    a trap giveaway (e.g., "don't enter", "ban", "fake").
+
+    Returns:
+        Dictionary with safety check results:
+            - is_safe: True if page appears safe
+            - safety_score: Score from 0-100 (higher = safer)
+            - bad_count: Number of bad words found
+            - good_count: Number of good words found (false positives)
+            - details: List of found bad words
+    """
+    text_lower = html_content.lower()
+
+    bad_count = 0
+    good_count = 0
+    found_bad_words = []
+
+    # Count forbidden words
+    for bad_word in FORBIDDEN_WORDS:
+        count = text_lower.count(bad_word.lower())
+        if count > 0:
+            bad_count += count
+            found_bad_words.append(bad_word.strip())
+
+    # Count good words (false positive indicators)
+    if bad_count > 0:
+        for good_word in GOOD_WORDS:
+            good_count += text_lower.count(good_word.lower())
+
+    # Calculate safety score
+    # Net bad = bad words minus false positives
+    net_bad = max(0, bad_count - good_count)
+
+    if net_bad == 0:
+        safety_score = 100
+        is_safe = True
+    elif net_bad <= 2:
+        safety_score = 50
+        is_safe = True  # Borderline, but allow
+    else:
+        safety_score = max(0, 100 - (net_bad * 20))
+        is_safe = False
+
+    return {
+        "is_safe": is_safe,
+        "safety_score": safety_score,
+        "bad_count": bad_count,
+        "good_count": good_count,
+        "net_bad": net_bad,
+        "details": found_bad_words,
+    }

--- a/backend/tests/fixtures/wishlist_page.html
+++ b/backend/tests/fixtures/wishlist_page.html
@@ -1,0 +1,870 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="description" content="Join our community with over 5,817,098 giveaways for Steam games and 1,161,636 users. Create your own giveaways and win Steam keys and games for free.">				<link rel="shortcut icon" href="https://cdn.steamgifts.com/img/favicon.ico">
+		<title>Free Giveaways and Keys for Steam Games</title>
+		<!-- Google Fonts -->
+		<link rel="preconnect" href="https://fonts.gstatic.com">
+		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600;700&family=Roboto+Mono&display=swap" rel="stylesheet">
+		<!-- Include FontAwesome -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+		<!-- Include CSS -->
+		<link rel="stylesheet" href="https://cdn.steamgifts.com/css/bundle-v10.css">
+		<!-- Include Scripts -->
+		<script nonce="z0Xgn53mhcTC2AGjuIqWjw==" src="https://cdn.steamgifts.com/js/bundle-v18.js"></script>
+		<script nonce="z0Xgn53mhcTC2AGjuIqWjw==">
+			'use strict';
+			const baseUrl = "\/giveaways";
+							const steamgifts_globals = Object.freeze({
+					xsrf_token: '8963e09cc778b961fab829c95b94de39',
+				});
+						</script>
+		<script nonce="z0Xgn53mhcTC2AGjuIqWjw==" src="https://cdn.steamgifts.com/js/referrals-v1.js"></script><meta name="viewport" content="width=1200">
+		<script nonce="z0Xgn53mhcTC2AGjuIqWjw==" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7519145598166360" crossorigin="anonymous"></script>
+							<style>
+				.adsbygoogle[data-ad-status="unfilled"], .adsbygoogle:empty {
+					height: 0 !important;
+				}
+			</style>
+			<script nonce="z0Xgn53mhcTC2AGjuIqWjw==">
+				(function(){
+					'use strict';
+					window.onload = function e() {
+						document.querySelectorAll('.kfuii').forEach(i => {
+							let e, s, h = 0;
+							if (e = i.querySelector('.adsbygoogle')) {
+								s = getComputedStyle(e);
+								h = e.clientHeight - (parseFloat(s.paddingTop) + parseFloat(s.paddingBottom));
+								if (h <= 15) {
+									e.parentNode.style.padding = 0;
+								}
+							}
+							if (h <= 15 && i.querySelector('.fanatical_container')) {
+								i.querySelectorAll('.fanatical_container').forEach(j => { j.classList.remove('hide'); });
+							}
+						});
+					}
+				})();
+			</script>
+						
+	</head>
+	<body>
+					<div class="lightbox hide">
+				<div class="lightbox-header">
+					<div class="lightbox-header-description">
+						<div class="lightbox-header-description-name"></div>
+						<div class="lightbox-header-description-count"></div>
+					</div>
+					<div class="lightbox-header-icons">
+						<i data-category="images" class="lightbox-header-icon fa fa-camera"></i>
+						<i data-category="videos" class="lightbox-header-icon fa fa-video-camera"></i>
+						<i class="lightbox-header-icon lightbox-header-icon--close fa fa-times"></i>
+					</div>
+				</div>
+				<div class="lightbox-status lightbox-status--loading">
+					<div>
+						<div class="lightbox-status-icon"><i class="fa fa-cog fa-spin"></i></div>
+						<div class="lightbox-status-text">Please wait</div>
+					</div>
+				</div>
+				<div class="lightbox-status lightbox-status--empty">
+					<div>
+						<div class="lightbox-status-icon"><i class="fa fa-picture-o"></i></div>
+						<div class="lightbox-status-text">No results</div>
+					</div>
+				</div>
+				<div class="lightbox-content">
+					<div class="lightbox-content-nav">
+						<div class="lightbox-content-nav-btn lightbox-content-nav-btn--prev">
+							<div class="lightbox-content-nav-btn-icon"><i class="fa fa-angle-left"></i></div>
+						</div>
+						<div class="lightbox-content-nav-btn lightbox-content-nav-btn--next">
+							<div class="lightbox-content-nav-btn-icon"><i class="fa fa-angle-right"></i></div>
+						</div>
+					</div>
+					<div class="lightbox-content-image"></div>
+				</div>
+				<div class="lightbox-footer-outer">
+					<div class="lightbox-footer-inner">
+						<div class="lightbox-thumbnails"></div>
+					</div>
+				</div>
+			</div>
+					<header>
+			<nav>
+										<div class="nav__left-container">
+							<div class="nav__button-container is-selected">
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/giveaways/new">
+											<i class="icon-green fa fa-fw fa-plus-circle"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Create a New Giveaway</p>
+												<p class="nav__row__summary__description">Get started with a new giveaway.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/giveaways/wishlist">
+											<i class="icon-blue fa fa-fw fa-users"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Community Wishlist</p>
+												<p class="nav__row__summary__description">Search for new games to share.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/giveaways/created">
+											<i class="icon-grey fa fa-fw fa-gift"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Created</p>
+												<p class="nav__row__summary__description">Check the status of your giveaways.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/giveaways/entered">
+											<i class="icon-red fa fa-fw fa-tag"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Entered</p>
+												<p class="nav__row__summary__description">Browse your giveaway entries.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/giveaways/won">
+											<i class="icon-yellow fa fa-fw fa-trophy"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Won</p>
+												<p class="nav__row__summary__description">Leave feedback for gifts you've won.</p>
+											</div>
+										</a>							
+									</div>
+								</div>	
+								<a class="nav__button nav__button--is-dropdown" href="/">Giveaways</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+							</div>
+														<div class="nav__button-container">
+								<a class="nav__button" href="/discussions/deals">Deals</a>
+							</div>
+							<div class="nav__button-container">
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/discussions/new">
+											<i class="icon-green fa fa-fw fa-plus-circle"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Create a New Discussion</p>
+												<p class="nav__row__summary__description">Start a topic on the forum.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/discussions/bookmarked">
+											<i class="icon-blue fa fa-fw fa-bookmark"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Bookmarked</p>
+												<p class="nav__row__summary__description">See the discussions you bookmarked.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/discussions/created">
+											<i class="icon-grey fa fa-fw fa-edit"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Created</p>
+												<p class="nav__row__summary__description">Check the status of your discussions.</p>
+											</div>
+										</a>
+									</div>
+								</div>	
+								<a class="nav__button nav__button--is-dropdown" href="/discussions/subscribed">Discussions</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+							</div>
+							<div class="nav__button-container">
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/support/tickets/new">
+											<i class="icon-green fa fa-fw fa-plus-circle"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Create a New Ticket</p>
+												<p class="nav__row__summary__description">Start a support ticket.</p>
+											</div>
+										</a>							
+									</div>
+								</div>	
+								<a class="nav__button nav__button--is-dropdown" href="/support">Support</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+							</div>
+														<div class="nav__button-container">
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/about/guidelines">
+											<i class="icon-blue fa fa-fw fa-file-text-o"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Guidelines</p>
+												<p class="nav__row__summary__description">Community rules and guidelines.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/about/faq">
+											<i class="icon-grey fa fa-fw fa-question-circle"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">FAQ</p>
+												<p class="nav__row__summary__description">Frequently asked questions.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/about/comment-formatting">
+											<i class="icon-red fa fa-fw fa-code"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Comment Formatting</p>
+												<p class="nav__row__summary__description">Syntax for writing comments.</p>
+											</div>
+										</a>
+									</div>
+								</div>	
+								<a class="nav__button nav__button--is-dropdown" href="/about/faq">Help</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+							</div>
+						</div>
+						<div class="nav__right-container">
+														<div class="nav__button-container nav__button-container--notification nav__button-container--inactive">
+								<a title="Giveaways Created" class="nav__button" href="/giveaways/created"><i class="fa fa-gift"></i></a>
+							</div>
+														<div class="nav__button-container nav__button-container--notification nav__button-container--inactive">
+								<a title="Giveaways Won" class="nav__button" href="/giveaways/won"><i class="fa fa-trophy"></i></a>
+							</div>
+							<div class="nav__button-container nav__button-container--notification nav__button-container--inactive">
+								<a title="Messages" class="nav__button" href="/messages"><i class="fa fa-envelope"></i></a>
+							</div>
+														<div class="nav__button-container">
+								<a class="nav__button nav__button--is-dropdown" href="/account">Account (<span class="nav__points">400</span>P / <span title="7.25">Level 7</span>)</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/account/settings/profile">
+											<i class="icon-green fa fa-fw fa-refresh"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Sync with Steam</p>
+												<p class="nav__row__summary__description">Last synced <span data-timestamp="1784161332">2 days</span> ago.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/stats">
+											<i class="icon-grey fa fa-fw fa-bar-chart"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">My Stats</p>
+												<p class="nav__row__summary__description">Learn more about your activity.</p>
+											</div>
+										</a>
+										<div class="nav__row is-clickable js__logout" data-form="do=logout&xsrf_token=8963e09cc778b961fab829c95b94de39">
+											<i class="icon-blue fa fa-fw fa-sign-out"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Logout</p>
+												<p class="nav__row__summary__description">Sign-out of your account.</p>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="nav__button-container nav__button-container--notification">
+								<a href="/user/TestUser" class="nav__avatar-outer-wrap">
+									<div class="nav__avatar-inner-wrap" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></div>
+								</a>
+							</div>
+						</div>
+									</nav>
+		</header>
+				<div class="popup popup--hide-games">
+			<i class="popup__icon fa fa-eye-slash"></i>
+			<p class="popup__heading">Would you like to hide all giveaways<br />for <span class="popup__heading__bold"></span>?</p>
+			<form method="post">
+				<input type="hidden" name="xsrf_token" value="deadbeefdeadbeefdeadbeefdeadbeef" />
+				<input type="hidden" name="game_id" value="" />
+				<input type="hidden" name="do" value="hide_giveaways_by_game_id" />
+				<div data-enabled="1" class="form__submit-button js__submit-hide-games"><i class="fa fa-check-circle"></i> Yes</div>
+				<div class="form__saving-button is-hidden is-disabled"><i class="fa fa-refresh fa-spin"></i> Please wait...</div>
+			</form>
+						<p class="popup__actions">
+				<a href="/account/settings/giveaways/filters">View Hidden Games</a>
+				<span class="b-close">Close</span>
+			</p>
+		</div>
+					<div class="featured__container">
+				<div class="featured__outer-wrap featured__outer-wrap--home" style="background-color: rgb(77,89,88);">
+					<div class="featured__inner-wrap">
+						<a href="/giveaway/dJtvt/melody-ball" class="global__image-outer-wrap global__image-outer-wrap--game-xlarge"><img src="https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/3656360/440cd30b937c895ef38b76d63a3f1482e689fafe/header.jpg?t=1760874286" /></a>
+						
+						<div class="featured__summary">
+							<div class="featured__heading">
+								<div class="featured__heading__medium"><a href="/giveaway/dJtvt/melody-ball">Melody Ball</a></div>
+								<div class="featured__heading__small">(2 Copies)</div>
+								<div class="featured__heading__small">(5P)</div>
+							</div>
+							<div class="featured__columns">				
+								<div class="featured__column"><i style="color:rgb(220,255,250);" class="fa fa-clock-o"></i> <span data-timestamp="1784377260">47 minutes</span> remaining</div>
+								<div class="featured__column featured__column--width-fill text-right"><span data-timestamp="1784370474">1 hour</span> ago by <a style="color:rgb(220,255,250);" href="/user/severesp">severesp</a></div><a href="/user/severesp" class="featured_giveaway_image_avatar" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+						</div>					</div>
+				</div>
+			</div>
+				<div class="page__outer-wrap">
+		<div class="page__inner-wrap">
+			<div class="widget-container">
+				<div class="sidebar" style="width: 300px; min-width: 300px;">
+					
+				<div class="sidebar__search-container">
+					<input class="sidebar__search-input" name="search-query" type="text" placeholder="Search..." value="" />
+					<i class="fa fa-search"></i>
+				</div>
+				<div class="sidebar__heading">Browse</div><ul class="sidebar__navigation">
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/">
+									<div class="sidebar__navigation__item__name">All</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item is-selected"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?type=wishlist"><i class="fa fa-caret-right"></i> 
+									<div class="sidebar__navigation__item__name">Wishlist</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?type=recommended">
+									<div class="sidebar__navigation__item__name">Recommended</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?copy_min=2">
+									<div class="sidebar__navigation__item__name">Multiple Copies</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?dlc=true">
+									<div class="sidebar__navigation__item__name">DLC</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?type=group">
+									<div class="sidebar__navigation__item__name">Group</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?type=new">
+									<div class="sidebar__navigation__item__name">New</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li></ul><div class="sidebar__heading">My Giveaways</div><ul class="sidebar__navigation">
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/created">
+									<div class="sidebar__navigation__item__name">Created</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/entered">
+									<div class="sidebar__navigation__item__name">Entered</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/won">
+									<div class="sidebar__navigation__item__name">Won</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li></ul><div class="kfuii"><a style=" margin: 25px 0 0 0;" class="fanatical_container hide vertical" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2F2k-megahits-2026-bundle"><img class="fanatical_img" src="https://hb.imgix.net/2ba4b565d865609b7e7e07e1302eff32629b0226.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=f18e2210926096360dc0432f148ca5bc" /><div class="fanatical_description"><div><span class="fanatical_new">New</span> <span class="fanatical_name">2K Megahits 2026 Bundle</span></div><div class="fanatical_date"><i class="fa fa-clock-o"></i><div>Started <span data-timestamp="1784311200">17 hours</span> ago</div></div></div><div class="fanatical_summary"><div class="fanatical_icons"><div class="fanatical_icon" style="background-image: url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div></div><div class="fanatical_pricing">$15.00</div></div></a>
+						<div style="padding-top: 35px;">
+							<!-- sg_homepage_top_responsive -->
+							<ins class="adsbygoogle"
+								 style="display:block"
+								 data-ad-client="ca-pub-7519145598166360"
+								 data-ad-slot="3652115722"
+								 data-ad-format="auto"
+								 data-full-width-responsive="true"></ins>
+							<script nonce="z0Xgn53mhcTC2AGjuIqWjw==">
+								 (adsbygoogle = window.adsbygoogle || []).push({});
+							</script>
+						</div>
+					</div>				</div>
+				<div>
+											<div class="pinned-giveaways-header">
+								<div class="pinned-giveaways-tab">Featured</div>
+															</div>
+							<div class="pinned-giveaways">
+								
+			<div class="giveaway__row-outer-wrap" data-game-id="4230380656">
+				<div class="giveaway__row-inner-wrap has-description">
+					<div class="giveaway__summary">
+						<h2 class="giveaway__heading">
+							<a class="giveaway__heading__name" href="/giveaway/GdMBH/sex-game-naughty-couple-episode-8">Sex Game - Naughty Couple -...</a><span class="giveaway__heading__thin">(50 Copies)</span><span class="giveaway__heading__thin">(5P)</span><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-steam&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Steam Store&quot;}]}]}" class="giveaway__icon" rel="nofollow noopener" target="_blank" href="https://store.steampowered.com/app/4073210?utm_source=SteamGifts"><i class="fa fa-fw fa-steam"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-camera&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Screenshots / Videos&quot;}]}]}" data-lightbox-id="4230380656" class="giveaway__icon fa fa-fw fa-camera"></i><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-search&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;More Giveaways&quot;}]}]}" title="Free Steam Giveaways and Keys for Sex Game - Naughty Couple - Episode 8" class="giveaway__icon" href="/game/eeKqF/sex-game-naughty-couple-episode-8"><i class="fa fa-fw fa-search"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-eye-slash&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Hide Giveaways&quot;}]}]}" data-popup="popup--hide-games" class="giveaway__icon giveaway__hide trigger-popup fa fa-fw fa-eye-slash"></i>
+						</h2>
+						<div class="giveaway__columns">
+							<div><i class="fa fa-clock-o"></i> <span data-timestamp="1784408340">9 hours</span> remaining</div><div class="giveaway__column--width-fill text-right"><span data-timestamp="1782378697">3 weeks</span> ago by <a class="giveaway__username" href="/user/EroticGamesClub">EroticGamesClub</a></div></div>
+							<div class="giveaway__links">
+								<a href="/giveaway/GdMBH/sex-game-naughty-couple-episode-8/entries"><span>2,830 entries</span></a>
+								<a href="/giveaway/GdMBH/sex-game-naughty-couple-episode-8"><span>4 comments</span></a>
+							</div>
+						</div><div class="giveaway__quick-entry-wrap"><div data-code="GdMBH" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--description" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-align-left&quot;,&quot;color&quot;:&quot;var(--color-blue-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;View Description&quot;}]}]}"><i class="fa fa-align-left"></i></div><form class="giveaway__quick-entry-form"><input type="hidden" name="xsrf_token" value="deadbeefdeadbeefdeadbeefdeadbeef" /><input type="hidden" name="do" value="" /><input type="hidden" name="code" value="GdMBH" /><div data-do="entry_insert" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--insert is-locked" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-plus-circle&quot;,&quot;color&quot;:&quot;var(--color-green-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Enter Giveaway&quot;}]}]}"><i class="fa fa-plus-circle"></i></div><div data-do="entry_delete" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--delete" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-minus-circle&quot;,&quot;color&quot;:&quot;var(--color-yellow-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Remove Entry&quot;}]}]}"><i class="fa fa-minus-circle"></i></div></form></div><a href="/user/EroticGamesClub" class="giveaway_image_avatar" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a><a class="giveaway_image_thumbnail" style="background-image:url(https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4073210/c3b742d45195128e9668ae2d89fc901208d51042/capsule_184x69.jpg?t=1760340742);" href="/giveaway/GdMBH/sex-game-naughty-couple-episode-8"></a>
+				</div>
+			</div>
+			<div class="giveaway__row-outer-wrap" data-game-id="4230384948">
+				<div class="giveaway__row-inner-wrap has-description">
+					<div class="giveaway__summary">
+						<h2 class="giveaway__heading">
+							<a class="giveaway__heading__name" href="/giveaway/T9bUz/sex-game-bdsm-episode-1">Sex Game - BDSM - Episode 1</a><span class="giveaway__heading__thin">(50 Copies)</span><span class="giveaway__heading__thin">(5P)</span><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-steam&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Steam Store&quot;}]}]}" class="giveaway__icon" rel="nofollow noopener" target="_blank" href="https://store.steampowered.com/app/4116410?utm_source=SteamGifts"><i class="fa fa-fw fa-steam"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-camera&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Screenshots / Videos&quot;}]}]}" data-lightbox-id="4230384948" class="giveaway__icon fa fa-fw fa-camera"></i><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-search&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;More Giveaways&quot;}]}]}" title="Free Steam Giveaways and Keys for Sex Game - BDSM - Episode 1" class="giveaway__icon" href="/game/gOe2d/sex-game-bdsm-episode-1"><i class="fa fa-fw fa-search"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-eye-slash&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Hide Giveaways&quot;}]}]}" data-popup="popup--hide-games" class="giveaway__icon giveaway__hide trigger-popup fa fa-fw fa-eye-slash"></i>
+						</h2>
+						<div class="giveaway__columns">
+							<div><i class="fa fa-clock-o"></i> <span data-timestamp="1784581140">2 days</span> remaining</div><div class="giveaway__column--width-fill text-right"><span data-timestamp="1782558983">3 weeks</span> ago by <a class="giveaway__username" href="/user/EroticGamesClub">EroticGamesClub</a></div></div>
+							<div class="giveaway__links">
+								<a href="/giveaway/T9bUz/sex-game-bdsm-episode-1/entries"><span>2,568 entries</span></a>
+								<a href="/giveaway/T9bUz/sex-game-bdsm-episode-1"><span>1 comment</span></a>
+							</div>
+						</div><div class="giveaway__quick-entry-wrap"><div data-code="T9bUz" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--description" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-align-left&quot;,&quot;color&quot;:&quot;var(--color-blue-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;View Description&quot;}]}]}"><i class="fa fa-align-left"></i></div><form class="giveaway__quick-entry-form"><input type="hidden" name="xsrf_token" value="deadbeefdeadbeefdeadbeefdeadbeef" /><input type="hidden" name="do" value="" /><input type="hidden" name="code" value="T9bUz" /><div data-do="entry_insert" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--insert is-locked" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-plus-circle&quot;,&quot;color&quot;:&quot;var(--color-green-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Enter Giveaway&quot;}]}]}"><i class="fa fa-plus-circle"></i></div><div data-do="entry_delete" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--delete" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-minus-circle&quot;,&quot;color&quot;:&quot;var(--color-yellow-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Remove Entry&quot;}]}]}"><i class="fa fa-minus-circle"></i></div></form></div><a href="/user/EroticGamesClub" class="giveaway_image_avatar" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a><a class="giveaway_image_thumbnail" style="background-image:url(https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4116410/09a9126bee9e3e8aea624bbf83e6765ae503f6c1/capsule_184x69.jpg?t=1762512469);" href="/giveaway/T9bUz/sex-game-bdsm-episode-1"></a>
+				</div>
+			</div>							</div>
+													<div class="page__heading">
+							<div class="page__heading__breadcrumbs"><a href="/">Giveaways</a></div>								<a href="/account/settings/giveaways">
+									<i class="fa fa-cog"></i>
+								</a>
+														</div>
+						<div>
+			<div class="giveaway__row-outer-wrap" data-game-id="4230286951">
+				<div class="giveaway__row-inner-wrap is-faded">
+					<div class="giveaway__summary">
+						<h2 class="giveaway__heading">
+							<a class="giveaway__heading__name" href="/giveaway/hVTVd/tomb-raider-iv-vi-remastered">Tomb Raider IV-VI Remastered</a><span class="giveaway__heading__thin">(30P)</span><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-steam&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Steam Store&quot;}]}]}" class="giveaway__icon" rel="nofollow noopener" target="_blank" href="https://store.steampowered.com/app/2525380?utm_source=SteamGifts"><i class="fa fa-fw fa-steam"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-camera&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Screenshots / Videos&quot;}]}]}" data-lightbox-id="4230286951" class="giveaway__icon fa fa-fw fa-camera"></i><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-search&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;More Giveaways&quot;}]}]}" title="Free Steam Giveaways and Keys for Tomb Raider IV-VI Remastered" class="giveaway__icon" href="/game/NjwTB/tomb-raider-iv-vi-remastered"><i class="fa fa-fw fa-search"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-eye-slash&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Hide Giveaways&quot;}]}]}" data-popup="popup--hide-games" class="giveaway__icon giveaway__hide trigger-popup fa fa-fw fa-eye-slash"></i>
+						</h2>
+						<div class="giveaway__columns">
+							<div><i class="fa fa-clock-o"></i> <span data-timestamp="1784849760">5 days</span> remaining</div><div class="giveaway__column--width-fill text-right"><span data-timestamp="1782340890">3 weeks</span> ago by <a class="giveaway__username" href="/user/AntiDagger">AntiDagger</a></div><a href="/giveaway/hVTVd/tomb-raider-iv-vi-remastered/region-restrictions" class="giveaway__column--region-restricted" title="Region Restricted"><i class="fa fa-fw fa-globe"></i></a></div>
+							<div class="giveaway__links">
+								<a href="/giveaway/hVTVd/tomb-raider-iv-vi-remastered/entries"><span>455 entries</span></a>
+								<a href="/giveaway/hVTVd/tomb-raider-iv-vi-remastered"><span>2 comments</span></a>
+							</div>
+						</div><div class="giveaway__quick-entry-wrap"><form class="giveaway__quick-entry-form"><input type="hidden" name="xsrf_token" value="deadbeefdeadbeefdeadbeefdeadbeef" /><input type="hidden" name="do" value="" /><input type="hidden" name="code" value="hVTVd" /><div data-do="entry_insert" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--insert" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-plus-circle&quot;,&quot;color&quot;:&quot;var(--color-green-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Enter Giveaway&quot;}]}]}"><i class="fa fa-plus-circle"></i></div><div data-do="entry_delete" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--delete" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-minus-circle&quot;,&quot;color&quot;:&quot;var(--color-yellow-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Remove Entry&quot;}]}]}"><i class="fa fa-minus-circle"></i></div></form></div><a href="/user/AntiDagger" class="giveaway_image_avatar" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a><a class="giveaway_image_thumbnail" style="background-image:url(https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2525380/40a0b53a061a9876030cea88b79e56eebf14aa56/capsule_184x69.jpg?t=1782771604);" href="/giveaway/hVTVd/tomb-raider-iv-vi-remastered"></a>
+				</div>
+			</div></div><div class="pagination"><div class="pagination__results">Displaying <strong>1</strong> to <strong>1</strong></div></div>						<div class="widget-container widget-container--margin-top" style="margin-top: 50px;">
+							<div class="widget-container">
+								<div>
+									<div class="block_header">
+										<a href="/discussions/deals" class="block_header_text">Deals</a>
+										<a href="/discussions/deals" class="block_header_link">View More</a>
+									</div>
+									<div class="table">
+										<div class="table__rows">
+											
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/sensualshakti" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/Hj3qx/humble-bundle-may-2024-humble-choice-54-bravery-mediterranea-out-of-stock">[Humble Bundle] May 2024 Humble Choice (#54) 💜 ...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Hj3qx/humble-bundle-may-2024-humble-choice-54-bravery-mediterranea-out-of-stock">417 Comments</a> - Last post <span data-timestamp="1784373816">9 minutes</span> ago by <a class="table__column__secondary-link" href="/user/ComNguoi">ComNguoi</a><a class="icon-green table__last-comment-icon" href="/go/comment/mc19dQ0"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/bttr" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/Hyzbb/steam-kairosoft-30th-anniversary-8-steam-bundles-final">[Steam] Kairosoft 30th Anniversary - 8 Steam bu...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Hyzbb/steam-kairosoft-30th-anniversary-8-steam-bundles-final">37 Comments</a> - Last post <span data-timestamp="1784372864">25 minutes</span> ago by <a class="table__column__secondary-link" href="/user/TWayne">TWayne</a><a class="icon-green table__last-comment-icon" href="/go/comment/Ug1sEYY"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Formidolosus" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/UBxEd/fanatical-build-your-own-best-of-cozy-bundle">[Fanatical] Build your own Best of Cozy Bundle 🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/UBxEd/fanatical-build-your-own-best-of-cozy-bundle">9 Comments</a> - Last post <span data-timestamp="1784371305">51 minutes</span> ago by <a class="table__column__secondary-link" href="/user/Chris76de">Chris76de</a><a class="icon-green table__last-comment-icon" href="/go/comment/6vlaQLE"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/MeguminShiro" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/Jd9T4/info-humble-bundlekey-expiration-info-list260621">[INFO]【📦 Humble Bundle】Key Expiration Info List...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Jd9T4/info-humble-bundlekey-expiration-info-list260621">107 Comments</a> - Last post <span data-timestamp="1784366566">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/ImpAtience">ImpAtience</a><a class="icon-green table__last-comment-icon" href="/go/comment/xTmSaBl"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Formidolosus" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/zIYa7/humble-bundle-2k-megahits-2026-bundle">[Humble Bundle] 2k Megahits 2026 Bundle🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/zIYa7/humble-bundle-2k-megahits-2026-bundle">21 Comments</a> - Last post <span data-timestamp="1784365792">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/s456dawn">s456dawn</a><a class="icon-green table__last-comment-icon" href="/go/comment/R3CtJIO"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Formidolosus" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/pNPjg/humble-bundle-even-steamier-sakura-special">[Humble Bundle] Even Steamier Sakura Special 🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/pNPjg/humble-bundle-even-steamier-sakura-special">19 Comments</a> - Last post <span data-timestamp="1784363317">3 hours</span> ago by <a class="table__column__secondary-link" href="/user/Petrucius">Petrucius</a><a class="icon-green table__last-comment-icon" href="/go/comment/VT9CMs2"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Kwek" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/eadAB/freesteamalienwarearena-shapez-dwarven-realms">[FREE][STEAM][ALIENWAREARENA] shapez, Dwarven R...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/eadAB/freesteamalienwarearena-shapez-dwarven-realms">5,201 Comments</a> - Last post <span data-timestamp="1784361651">3 hours</span> ago by <a class="table__column__secondary-link" href="/user/Yamiji">Yamiji</a><a class="icon-green table__last-comment-icon" href="/go/comment/p5Dpt8C"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+														</div>
+									</div>
+								</div>
+							</div>
+							<div class="widget-container">
+								<div>
+									<div class="block_header">
+										<a href="/discussions" class="block_header_text">Discussions</a>
+										<a href="/discussions" class="block_header_link">View More</a>
+									</div>
+									<div class="table">
+										<div class="table__rows">
+											
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/X37" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/tvIFu/does-this-count-to-level">Does this count to level?!?</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/tvIFu/does-this-count-to-level">39 Comments</a> - Last post <span data-timestamp="1784374233">2 minutes</span> ago by <a class="table__column__secondary-link" href="/user/Lugum">Lugum</a><a class="icon-green table__last-comment-icon" href="/go/comment/NwPOZkZ"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/quinnix" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/sG54G/lv3-12th-cakeday-train-ends-july-29th">[Lv3+] 12th cakeday train (ends July 29th)</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/sG54G/lv3-12th-cakeday-train-ends-july-29th">109 Comments</a> - Last post <span data-timestamp="1784373939">7 minutes</span> ago by <a class="table__column__secondary-link" href="/user/Unekha">Unekha</a><a class="icon-green table__last-comment-icon" href="/go/comment/wI4EEj5"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/DancingXmas" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/KkcLg/my-math-aint-mathing">My math ain&#039;t mathing</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/KkcLg/my-math-aint-mathing">71 Comments</a> - Last post <span data-timestamp="1784373769">10 minutes</span> ago by <a class="table__column__secondary-link" href="/user/iHoriZonT">iHoriZonT</a><a class="icon-green table__last-comment-icon" href="/go/comment/hVlG58G"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/cprn" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/LIxeK/is-it-okay-to-make-a-high-demand-game-ga-but">Is it okay to make a high-demand game GA, but...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/LIxeK/is-it-okay-to-make-a-high-demand-game-ga-but">67 Comments</a> - Last post <span data-timestamp="1784373619">12 minutes</span> ago by <a class="table__column__secondary-link" href="/user/cprn">cprn</a><a class="icon-green table__last-comment-icon" href="/go/comment/kQ3Vfjj"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/DancingXmas" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/dG8xN/life-is-better-when-your-dances-too-723-giveaways-running">Life is better when your 💙 dances too [72/??][3...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/dG8xN/life-is-better-when-your-dances-too-723-giveaways-running">388 Comments</a> - Last post <span data-timestamp="1784373546">14 minutes</span> ago by <a class="table__column__secondary-link" href="/user/LumpyCreature">LumpyCreature</a><a class="icon-green table__last-comment-icon" href="/go/comment/LeSj1UG"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/thekuribo" style="background-image:url(https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/72/7242fe76ba249e3859b25628a53456e16e5ecfe6_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/NIHP5/guess-the-game-3-screenshot-boogaloo">Guess the Game 3: Screenshot Boogaloo</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/NIHP5/guess-the-game-3-screenshot-boogaloo">18,673 Comments</a> - Last post <span data-timestamp="1784373075">21 minutes</span> ago by <a class="table__column__secondary-link" href="/user/weissnicht01">weissnicht01</a><a class="icon-green table__last-comment-icon" href="/go/comment/gKf07sL"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/DancingXmas" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/Bcrnx/07-xmas-year-round-summer-break-july-2026-1010-giveaways">[07] Xmas Year Round - Summer Break July 2026 [...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Bcrnx/07-xmas-year-round-summer-break-july-2026-1010-giveaways">338 Comments</a> - Last post <span data-timestamp="1784370224">1 hour</span> ago by <a class="table__column__secondary-link" href="/user/yannbz">yannbz</a><a class="icon-green table__last-comment-icon" href="/go/comment/RZIpBn9"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+														</div>
+									</div>
+								</div>
+							</div>
+						</div>
+														<div class="widget-container widget-container--margin-top" style="margin-top: 50px;">
+									<div>
+										<div class="block_header">
+											<div class="block_header_text">New Bundles</div>
+										</div>
+										<div class="table">
+											<div class="table__rows">
+																									<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2F2k-megahits-2026-bundle&amp;product_id=a40c8c78f45e74570f9e1cc989d66385">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/2ba4b565d865609b7e7e07e1302eff32629b0226.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=f18e2210926096360dc0432f148ca5bc');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="fanatical_new">New</span> <span class="homepage_table_column_heading">2K Megahits 2026 Bundle</span></p>
+																<div>Started <span data-timestamp="1784311200">17 hours</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$15.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Feven-steamier-sakura-special&amp;product_id=5a82902da32c5411732f469a8a7d23c2">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/6c3944173e6d9ac9293ee5ed0850c725c3a819f9.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=ed3c1db4d08a0b65262c45a27414a9eb');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="fanatical_new">New</span> <span class="homepage_table_column_heading">Even Steamier Sakura Special</span></p>
+																<div>Started <span data-timestamp="1784311200">17 hours</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$9.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Fliminal-spaces&amp;product_id=e7c4f126101095b4c6dd568202862335">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/15e37e03f1c809f954f11f62c79ab52281cdd9db.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=2f29f270980b75d2720660abb26328b2');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Liminal Spaces</span></p>
+																<div>Started <span data-timestamp="1784138400">2 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$10.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Fhandhelds-bundle&amp;product_id=013e28e2c90f1e91814d1bea76f80011">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/b3359ab45da0cb979a5ab3e3a37c265ab43a35d4.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=bda1873177856b1d645f9a935856c6fe');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Humble Handhelds Bundle</span></p>
+																<div>Started <span data-timestamp="1784138400">2 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$5.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Fnarrative-12-for-10-bundle&amp;product_id=5662051751f578c4386d64f44a01031c">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/ebb227b430ae61b4a2378a78892dea15dff5c0a2.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=bee2fcb2842836e395556801d3ec67c7');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Narrative 12 for $10 Bundle</span></p>
+																<div>Started <span data-timestamp="1783706400">1 week</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$10.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fbundle%2Fpremiere-bundle&amp;product_id=e32bd04db5fdd0ef921c5a94c728d455">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/89d8dca1-e7d0-47d2-95d3-24ec29d096ac.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="fanatical_new">New</span> <span class="homepage_table_column_heading">Premiere Bundle</span></p>
+																<div>Started <span data-timestamp="1784293200">22 hours</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$9.99</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fpick-and-mix%2Fbuild-your-own-best-of-tabletop-bundle&amp;product_id=1b0872a9a0da0a10f191e973fe72f561">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/67aeb835-11be-485e-8ed5-f530ea1e78ad.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="fanatical_new">New</span> <span class="homepage_table_column_heading">Build your own Best of Tabletop Bundle</span></p>
+																<div>Started <span data-timestamp="1784206800">1 day</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$8.99</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fbundle%2F50-game-changing-sound-fx-collection&amp;product_id=449ea49cbe73a0add5d3fdd40a72460c">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/090f34bd-eb61-46e6-862a-a9328735f45b.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">50 Game Changing Sound FX Collection</span></p>
+																<div>Started <span data-timestamp="1784192400">2 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$1.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fpick-and-mix%2Fbuild-your-own-best-of-bento-bundle&amp;product_id=446896e1ba601c479fb702dbb62b4671">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/d37c545f-e70c-4a58-87a7-9bd7d1b5bfad.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Build your own Best of Bento Bundle (2026)</span></p>
+																<div>Started <span data-timestamp="1784120400">2 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$9.99</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fpick-and-mix%2Fbuild-your-own-best-of-cozy-bundle&amp;product_id=63262b3a2f75fc2df4fa235392aa4ace">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/beaa2698-007f-4df2-bcd3-be9719a7da70.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Build your own Best of Cozy Bundle</span></p>
+																<div>Started <span data-timestamp="1784034000">3 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$5.55</span>
+															</div>
+														</a>
+													</div>
+																								</div>
+										</div>
+									</div>
+								</div>
+												</div>
+			</div>
+		</div>
+	</div>
+		<footer>
+			<div class="footer_inner_wrap">
+				<div class="footer_columns">
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-gift"></i>
+							<div class="footer_column_name">SteamGifts</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/">Giveaways</a>
+							<a class="footer_column_link" href="/discussions/deals">Deals</a>
+							<a class="footer_column_link" href="/discussions">Discussions</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-file-text-o"></i>
+							<div class="footer_column_name">Browse</div>
+						</div>
+						<div class="footer_column_links">
+														<a class="footer_column_link" href="/stats">Community Stats</a>
+														<a class="footer_column_link" href="/archive">Giveaway Archive</a>
+							<a class="footer_column_link" href="/roles">User Roles</a>
+							<a class="footer_column_link" href="/users">User List</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-question-circle"></i>
+							<div class="footer_column_name">Help</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/about/guidelines">Guidelines</a>
+							<a class="footer_column_link" href="/about/faq">FAQ</a>
+							<a class="footer_column_link" href="/about/comment-formatting">Comment Formatting</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-gavel"></i>
+							<div class="footer_column_name">Legal</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/legal/privacy-policy">Privacy Policy</a>
+							<a class="footer_column_link" href="/legal/cookie-policy">Cookie Policy</a>
+							<a class="footer_column_link" href="/legal/terms-of-service">Terms of Service</a>
+						</div>
+					</div>
+				</div>
+				<div class="footer_lower">
+					<div class="footer_steam">
+						<div>Powered by</div>
+						<a class="footer_steam_logo" href="https://store.steampowered.com" target="_blank" rel="nofollow noopener">
+							<i class="fa fa-steam"></i>
+							<div>Steam</div>
+						</a>
+					</div>
+					<div class="footer_sites">
+						<a title="Steam Trading" href="https://www.steamtrades.com">SteamTrades.com</a>
+						<a title="Free Steam Keys and Giveaways" href="https://www.steamgifts.com">SteamGifts.com</a>
+					</div>
+				</div>
+			</div>
+		</footer>
+	<script nonce="z0Xgn53mhcTC2AGjuIqWjw==">(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.nonce='z0Xgn53mhcTC2AGjuIqWjw==';d.innerHTML="window.__CF$cv$params={r:'a1d12b6b9a53d34c',t:'MTc4NDM3NDM4Ng=='};var a=document.createElement('script');a.nonce='z0Xgn53mhcTC2AGjuIqWjw==';a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/backend/tests/unit/test_steamgifts_parser.py
+++ b/backend/tests/unit/test_steamgifts_parser.py
@@ -1,0 +1,89 @@
+"""Regression tests for utils.steamgifts_parser against a real captured page.
+
+tests/fixtures/wishlist_page.html is a sanitized copy of a live
+steamgifts.com/giveaways/search?type=wishlist page (captured 2026-07-18,
+logged-in identity and XSRF tokens scrubbed). It contains:
+
+- a pinned "Featured" ad section (div.pinned-giveaways) with 2 ad giveaways
+- exactly one real wishlist giveaway: Tomb Raider IV-VI Remastered
+  (code hVTVd, 30P)
+- the nav bar with the user's points (400) and profile link (TestUser)
+
+If SteamGifts changes their markup again, these tests fail loudly instead of
+the bot silently scraping wrong data. Refresh the fixture with
+tests/scripts/fetch_wishlist_page.py (scrub username/avatar/xsrf before
+committing).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from utils import steamgifts_parser as parser
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+@pytest.fixture(scope="module")
+def wishlist_html() -> str:
+    return (FIXTURES / "wishlist_page.html").read_text(encoding="utf-8")
+
+
+class TestWishlistPageFixture:
+    def test_ads_excluded_real_giveaway_kept(self, wishlist_html):
+        giveaways = parser.parse_giveaway_list(wishlist_html, mark_wishlist=True)
+
+        assert len(giveaways) == 1
+        ga = giveaways[0]
+        assert ga["code"] == "hVTVd"
+        assert ga["game_name"] == "Tomb Raider IV-VI Remastered"
+        assert ga["price"] == 30
+        assert ga["is_wishlist"] is True
+        assert ga["game_id"] == 2525380
+        assert ga["end_time"] is not None
+
+    def test_mark_wishlist_false(self, wishlist_html):
+        giveaways = parser.parse_giveaway_list(wishlist_html, mark_wishlist=False)
+        assert len(giveaways) == 1
+        assert giveaways[0]["is_wishlist"] is False
+
+    def test_pinned_ads_present_in_html(self, wishlist_html):
+        # Guard against a silently outdated fixture: the ad section must
+        # actually be there for the exclusion test above to mean anything.
+        assert 'class="pinned-giveaways"' in wishlist_html
+        assert wishlist_html.count('giveaway__row-inner-wrap') == 3  # 2 ads + 1 real
+
+    def test_user_points(self, wishlist_html):
+        assert parser.parse_user_points(wishlist_html) == 400
+
+    def test_username(self, wishlist_html):
+        assert parser.parse_username(wishlist_html) == "TestUser"
+
+    def test_xsrf_token(self, wishlist_html):
+        assert parser.extract_xsrf_token(wishlist_html) == "deadbeefdeadbeefdeadbeefdeadbeef"
+
+
+class TestParserEdgeCases:
+    def test_empty_page(self):
+        assert parser.parse_giveaway_list("<html><body></body></html>") == []
+        assert parser.parse_won_giveaways("<html><body></body></html>") == []
+        assert parser.parse_entered_giveaways("<html><body></body></html>") == []
+        assert parser.parse_user_points("<html><body></body></html>") is None
+        assert parser.parse_username("<html><body></body></html>") is None
+        assert parser.extract_xsrf_token("<html><body></body></html>") is None
+        assert parser.parse_giveaway_game_id("<html><body></body></html>") is None
+
+    def test_malformed_points_raises(self):
+        html = '<span class="nav__points">no digits</span>'
+        with pytest.raises(ValueError, match="Could not parse points"):
+            parser.parse_user_points(html)
+
+    def test_safety_check_pure(self):
+        clean = parser.check_page_safety("a lovely giveaway, enjoy")
+        assert clean["is_safe"] is True
+        assert clean["safety_score"] == 100
+
+        trap = parser.check_page_safety(
+            "please do not enter this is fake and you will get a ban, bot trap"
+        )
+        assert trap["is_safe"] is False

--- a/backend/tests/unit/test_utils_steamgifts_client.py
+++ b/backend/tests/unit/test_utils_steamgifts_client.py
@@ -12,6 +12,7 @@ from core.exceptions import (
 from core.exceptions import (
     SteamGiftsSessionExpiredError as SteamGiftsAuthError,
 )
+from utils import steamgifts_parser
 from utils.steamgifts_client import (
     SteamGiftsClient,
     SteamGiftsNotFoundError,
@@ -337,7 +338,7 @@ async def test_parse_giveaway_element_success(steamgifts_client):
     soup = BeautifulSoup(html, "html.parser")
     element = soup.find("div", class_="giveaway__row-inner-wrap")
 
-    result = steamgifts_client._parse_giveaway_element(element)
+    result = steamgifts_parser.parse_giveaway_element(element)
 
     assert result is not None
     assert result["code"] == "XyZ99"
@@ -362,7 +363,7 @@ async def test_parse_giveaway_element_missing_link(steamgifts_client):
     soup = BeautifulSoup(html, "html.parser")
     element = soup.find("div", class_="giveaway__row-inner-wrap")
 
-    result = steamgifts_client._parse_giveaway_element(element)
+    result = steamgifts_parser.parse_giveaway_element(element)
 
     assert result is None
 

--- a/backend/tests/unit/test_wins.py
+++ b/backend/tests/unit/test_wins.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from core.time import utcnow
+from utils import steamgifts_parser
 
 
 class TestSteamGiftsClientGetWonGiveaways:
@@ -52,16 +53,12 @@ class TestSteamGiftsClientGetWonGiveaways:
         """Test parsing won giveaways from HTML."""
         from bs4 import BeautifulSoup
 
-        from utils.steamgifts_client import SteamGiftsClient
-
-        client = SteamGiftsClient(phpsessid="test", user_agent="test")
-
         soup = BeautifulSoup(sample_won_html, "html.parser")
         rows = soup.find_all("div", class_="table__row-inner-wrap")
 
         results = []
         for row in rows:
-            result = client._parse_won_giveaway_row(row)
+            result = steamgifts_parser.parse_won_giveaway_row(row)
             if result:
                 results.append(result)
 
@@ -111,14 +108,11 @@ class TestSteamGiftsClientGetWonGiveaways:
         """Test parsing fails gracefully when link is missing."""
         from bs4 import BeautifulSoup
 
-        from utils.steamgifts_client import SteamGiftsClient
-
         html = '<div class="table__row-inner-wrap"><div>No link here</div></div>'
         soup = BeautifulSoup(html, "html.parser")
         row = soup.find("div", class_="table__row-inner-wrap")
 
-        client = SteamGiftsClient(phpsessid="test", user_agent="test")
-        result = client._parse_won_giveaway_row(row)
+        result = steamgifts_parser.parse_won_giveaway_row(row)
 
         assert result is None
 


### PR DESCRIPTION
- New utils/steamgifts_parser.py: all BeautifulSoup parsing as pure functions (giveaway lists, won/entered rows, user points/username, XSRF token, game id, safety check). Convention: None/[] for not found, ValueError for malformed content
- SteamGiftsClient shrinks from 1271 to 812 lines and only does HTTP, retries, rate limiting and error mapping; FORBIDDEN_WORDS/GOOD_WORDS re-exported for compatibility
- tests/fixtures/wishlist_page.html: sanitized real wishlist page (Featured ad section + one real giveaway; identity and XSRF scrubbed)
- New fixture-based regression tests so a SteamGifts markup change fails loudly instead of silently scraping wrong data