### PR TITLE
Scan updates & robustness

### DIFF
--- a/backend/src/repositories/giveaway.py
+++ b/backend/src/repositories/giveaway.py
@@ -8,7 +8,7 @@ giveaway visibility.
 from datetime import datetime, timedelta
 from typing import Any
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.time import utcnow
@@ -398,6 +398,39 @@ class GiveawayRepository(BaseRepository[Giveaway]):
 
         result = await self.session.execute(query)
         return list(result.scalars().all())
+
+    async def unset_wishlist_except(self, codes: set[str]) -> int:
+        """
+        Clear the wishlist flag on active giveaways not in ``codes``.
+
+        Called after a *complete* wishlist scan: any active giveaway still
+        flagged wishlist but absent from the scan is no longer on the user's
+        Steam wishlist. Expired giveaways keep their flag as history.
+
+        Args:
+            codes: Giveaway codes seen in the completed wishlist scan
+
+        Returns:
+            Number of giveaways whose flag was cleared
+
+        Note:
+            This method does NOT commit the transaction. The caller must
+            call session.commit() to persist changes to the database.
+        """
+        now = utcnow()
+        stmt = (
+            update(self.model)
+            .where(
+                self.model.is_wishlist == True,  # noqa: E712
+                self.model.end_time.isnot(None),
+                self.model.end_time > now,
+                self.model.code.notin_(codes),
+            )
+            .values(is_wishlist=False)
+        )
+        result = await self.session.execute(stmt)
+        # execute() is typed as Result, but UPDATE always yields a CursorResult.
+        return int(result.rowcount or 0)  # type: ignore[attr-defined]
 
     async def get_won(
         self, limit: int | None = None, offset: int | None = None

--- a/backend/src/services/giveaway_sync.py
+++ b/backend/src/services/giveaway_sync.py
@@ -7,11 +7,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.exceptions import SteamGiftsError
 from core.time import utcnow
 from models.giveaway import Giveaway
+from repositories.activity_log import ActivityLogRepository
 from repositories.giveaway import GiveawayRepository
 from services.game_service import GameService
-from utils.steamgifts_client import SteamGiftsClient
+from utils.steamgifts_client import SteamGiftsClient, SteamGiftsScrapeDriftError
 
 logger = structlog.get_logger()
+
+# SteamGifts renders 50 giveaways per listing page; a shorter page is the
+# last one, which tells us a multi-page scan saw the complete list.
+GIVEAWAYS_PER_PAGE = 50
 
 
 class GiveawaySyncMixin:
@@ -62,6 +67,11 @@ class GiveawaySyncMixin:
         """
         new_count = 0
         updated_count = 0
+        scraped_codes: set[str] = set()
+        # True when we saw the end of the list (an empty or short page), as
+        # opposed to stopping at the page cap or on an error. Only a complete
+        # wishlist scan is allowed to un-stick stale wishlist flags below.
+        scan_complete = False
 
         for page in range(1, pages + 1):
             try:
@@ -72,30 +82,63 @@ class GiveawaySyncMixin:
                     dlc_only=dlc_only,
                     min_copies=min_copies,
                 )
-
-                for ga_data in giveaways_data:
-                    # Check if exists
-                    existing = await self.giveaway_repo.get_by_code(ga_data["code"])
-
-                    # Cache game data if we have game_id
-                    if ga_data.get("game_id"):
-                        try:
-                            await self.game_service.get_or_fetch_game(ga_data["game_id"])
-                        except Exception as e:
-                            logger.error("game_cache_failed", game_id=ga_data["game_id"], error=str(e))
-
-                    if existing:
-                        # Update existing giveaway
-                        await self._update_giveaway(existing, ga_data)
-                        updated_count += 1
-                    else:
-                        # Create new giveaway
-                        await self._create_giveaway(ga_data)
-                        new_count += 1
-
+            except SteamGiftsScrapeDriftError as e:
+                # The page parsed to zero rows without a no-results marker:
+                # the markup likely changed. Surface it in the activity log so
+                # the UI shows it, and don't treat the scan as complete.
+                logger.error("scrape_drift_detected", page=page, error=str(e))
+                await ActivityLogRepository(self.session).create(
+                    level="warning",
+                    event_type="error",
+                    message=(
+                        "Scan parsed 0 giveaways from a non-empty page - "
+                        "SteamGifts may have changed their markup"
+                    ),
+                )
+                break
             except SteamGiftsError as e:
                 logger.error("giveaway_page_fetch_failed", page=page, error=str(e))
                 break
+
+            if not giveaways_data:
+                # Legitimate end of the list (no-results marker present).
+                scan_complete = True
+                break
+
+            for ga_data in giveaways_data:
+                scraped_codes.add(ga_data["code"])
+
+                # Check if exists
+                existing = await self.giveaway_repo.get_by_code(ga_data["code"])
+
+                # Cache game data if we have game_id
+                if ga_data.get("game_id"):
+                    try:
+                        await self.game_service.get_or_fetch_game(ga_data["game_id"])
+                    except Exception as e:
+                        logger.error("game_cache_failed", game_id=ga_data["game_id"], error=str(e))
+
+                if existing:
+                    # Update existing giveaway
+                    await self._update_giveaway(existing, ga_data)
+                    updated_count += 1
+                else:
+                    # Create new giveaway
+                    await self._create_giveaway(ga_data)
+                    new_count += 1
+
+            if len(giveaways_data) < GIVEAWAYS_PER_PAGE:
+                # Short page = last page of the list.
+                scan_complete = True
+                break
+
+        # A complete wishlist scan is the source of truth for the wishlist
+        # flag: clear it on active giveaways that no longer appear (the game
+        # was removed from the Steam wishlist). Never after partial scans.
+        if giveaway_type == "wishlist" and scan_complete:
+            cleared = await self.giveaway_repo.unset_wishlist_except(scraped_codes)
+            if cleared:
+                logger.info("wishlist_flags_cleared", count=cleared)
 
         await self.session.commit()
         return new_count, updated_count
@@ -252,6 +295,8 @@ class GiveawaySyncMixin:
         if ga_data.get("game_id") and not giveaway.game_id:
             giveaway.game_id = ga_data["game_id"]
 
-        # Update wishlist flag (can change from False to True, but not back)
+        # Set the wishlist flag when this row came from a wishlist scan.
+        # The reverse direction (un-sticking removed games) is handled by
+        # unset_wishlist_except after a complete wishlist scan.
         if ga_data.get("is_wishlist"):
             giveaway.is_wishlist = True

--- a/backend/src/utils/steamgifts_client.py
+++ b/backend/src/utils/steamgifts_client.py
@@ -39,6 +39,15 @@ class SteamGiftsUnsafeError(SteamGiftsError):
         self.safety_score = safety_score
 
 
+class SteamGiftsScrapeDriftError(SteamGiftsError):
+    """Raised when a listing page yields zero giveaways but lacks the
+    'no results' marker — the site markup has likely changed and the
+    scraper needs updating. Never raised for legitimately empty lists."""
+
+    def __init__(self, message: str, page: int = 0):
+        super().__init__(message, code="SG_006", details={"page": page})
+
+
 
 class SteamGiftsClient:
     """
@@ -441,9 +450,27 @@ class SteamGiftsClient:
                 details={"status_code": response.status_code},
             )
 
-        return parser.parse_giveaway_list(
+        giveaways = parser.parse_giveaway_list(
             response.text, mark_wishlist=giveaway_type == "wishlist"
         )
+
+        # Zero rows without the explicit "No results were found." marker means
+        # the page is unrecognizable — fail loudly instead of silently
+        # returning an empty list (see the Featured-section regression).
+        if not giveaways and not parser.has_no_results_marker(response.text):
+            logger.warning(
+                "scrape_drift_suspected",
+                page=page,
+                giveaway_type=giveaway_type,
+                html_size=len(response.text),
+            )
+            raise SteamGiftsScrapeDriftError(
+                "Giveaway page parsed to zero rows without a no-results marker "
+                "- SteamGifts markup may have changed",
+                page=page,
+            )
+
+        return giveaways
 
     async def enter_giveaway(self, giveaway_code: str) -> bool:
         """

--- a/backend/src/utils/steamgifts_parser.py
+++ b/backend/src/utils/steamgifts_parser.py
@@ -29,6 +29,17 @@ FORBIDDEN_WORDS = (" ban", " fake", " bot", " not enter", " don't enter", " do n
 GOOD_WORDS = (" bank", " banan", " both", " band", " banner", " bang")
 
 
+def has_no_results_marker(html: str) -> bool:
+    """True when the page explicitly says the search matched nothing.
+
+    SteamGifts renders ``<div class="pagination pagination--no-results">``
+    ("No results were found.") on legitimately empty result pages. Zero parsed
+    giveaways WITHOUT this marker means the markup has likely changed and the
+    scraper is broken (scrape drift), not that the list is empty.
+    """
+    return "pagination--no-results" in html
+
+
 def extract_xsrf_token(html: str) -> str | None:
     """Extract the XSRF token embedded in any authenticated page, or None."""
     soup = BeautifulSoup(html, "html.parser")

--- a/backend/src/workers/automation.py
+++ b/backend/src/workers/automation.py
@@ -93,8 +93,10 @@ async def automation_cycle() -> dict[str, Any]:
             logger.info("automation_step", step="scan_wishlist")
 
             try:
+                # Same page cap as the regular scan; the sync stops early at
+                # the end of the list, so small wishlists cost one request.
                 wishlist_new, wishlist_updated = await giveaway_service.sync_giveaways(
-                    pages=1,
+                    pages=max_pages,
                     giveaway_type="wishlist"
                 )
                 results["wishlist"] = {

--- a/backend/src/workers/scanner.py
+++ b/backend/src/workers/scanner.py
@@ -59,13 +59,15 @@ async def scan_giveaways() -> dict[str, Any]:
                 pages=max_pages
             )
 
-            # Also scan wishlist giveaways (single page, like the automation
-            # cycle) so the Wishlist tab is populated by manual scans too.
-            # A wishlist failure shouldn't fail the whole scan.
+            # Also scan wishlist giveaways so the Wishlist tab is populated by
+            # manual scans too. Uses the same page cap as the regular scan;
+            # the sync stops early at the end of the list, so small wishlists
+            # cost a single request. A wishlist failure shouldn't fail the
+            # whole scan.
             wishlist_new = wishlist_updated = 0
             try:
                 wishlist_new, wishlist_updated = await ctx.giveaway_service.sync_giveaways(
-                    pages=1, giveaway_type="wishlist"
+                    pages=max_pages, giveaway_type="wishlist"
                 )
             except Exception as e:
                 logger.error("scan_wishlist_failed", error=str(e))

--- a/backend/tests/fixtures/empty_search_page.html
+++ b/backend/tests/fixtures/empty_search_page.html
@@ -1,0 +1,870 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="description" content="Join our community with over 5,817,098 giveaways for Steam games and 1,161,636 users. Create your own giveaways and win Steam keys and games for free.">				<link rel="shortcut icon" href="https://cdn.steamgifts.com/img/favicon.ico">
+		<title>Free Giveaways and Keys for Steam Games - Searching 'xkcdnonexistentgame42'</title>
+		<!-- Google Fonts -->
+		<link rel="preconnect" href="https://fonts.gstatic.com">
+		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600;700&family=Roboto+Mono&display=swap" rel="stylesheet">
+		<!-- Include FontAwesome -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+		<!-- Include CSS -->
+		<link rel="stylesheet" href="https://cdn.steamgifts.com/css/bundle-v10.css">
+		<!-- Include Scripts -->
+		<script nonce="uURbx5JWOI6cbItR2OB5FA==" src="https://cdn.steamgifts.com/js/bundle-v18.js"></script>
+		<script nonce="uURbx5JWOI6cbItR2OB5FA==">
+			'use strict';
+			const baseUrl = "\/giveaways";
+							const steamgifts_globals = Object.freeze({
+					xsrf_token: '8963e09cc778b961fab829c95b94de39',
+				});
+						</script>
+		<script nonce="uURbx5JWOI6cbItR2OB5FA==" src="https://cdn.steamgifts.com/js/referrals-v1.js"></script><meta name="viewport" content="width=1200">
+		<script nonce="uURbx5JWOI6cbItR2OB5FA==" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7519145598166360" crossorigin="anonymous"></script>
+							<style>
+				.adsbygoogle[data-ad-status="unfilled"], .adsbygoogle:empty {
+					height: 0 !important;
+				}
+			</style>
+			<script nonce="uURbx5JWOI6cbItR2OB5FA==">
+				(function(){
+					'use strict';
+					window.onload = function e() {
+						document.querySelectorAll('.xiyplq').forEach(i => {
+							let e, s, h = 0;
+							if (e = i.querySelector('.adsbygoogle')) {
+								s = getComputedStyle(e);
+								h = e.clientHeight - (parseFloat(s.paddingTop) + parseFloat(s.paddingBottom));
+								if (h <= 15) {
+									e.parentNode.style.padding = 0;
+								}
+							}
+							if (h <= 15 && i.querySelector('.fanatical_container')) {
+								i.querySelectorAll('.fanatical_container').forEach(j => { j.classList.remove('hide'); });
+							}
+						});
+					}
+				})();
+			</script>
+						
+	</head>
+	<body>
+					<div class="lightbox hide">
+				<div class="lightbox-header">
+					<div class="lightbox-header-description">
+						<div class="lightbox-header-description-name"></div>
+						<div class="lightbox-header-description-count"></div>
+					</div>
+					<div class="lightbox-header-icons">
+						<i data-category="images" class="lightbox-header-icon fa fa-camera"></i>
+						<i data-category="videos" class="lightbox-header-icon fa fa-video-camera"></i>
+						<i class="lightbox-header-icon lightbox-header-icon--close fa fa-times"></i>
+					</div>
+				</div>
+				<div class="lightbox-status lightbox-status--loading">
+					<div>
+						<div class="lightbox-status-icon"><i class="fa fa-cog fa-spin"></i></div>
+						<div class="lightbox-status-text">Please wait</div>
+					</div>
+				</div>
+				<div class="lightbox-status lightbox-status--empty">
+					<div>
+						<div class="lightbox-status-icon"><i class="fa fa-picture-o"></i></div>
+						<div class="lightbox-status-text">No results</div>
+					</div>
+				</div>
+				<div class="lightbox-content">
+					<div class="lightbox-content-nav">
+						<div class="lightbox-content-nav-btn lightbox-content-nav-btn--prev">
+							<div class="lightbox-content-nav-btn-icon"><i class="fa fa-angle-left"></i></div>
+						</div>
+						<div class="lightbox-content-nav-btn lightbox-content-nav-btn--next">
+							<div class="lightbox-content-nav-btn-icon"><i class="fa fa-angle-right"></i></div>
+						</div>
+					</div>
+					<div class="lightbox-content-image"></div>
+				</div>
+				<div class="lightbox-footer-outer">
+					<div class="lightbox-footer-inner">
+						<div class="lightbox-thumbnails"></div>
+					</div>
+				</div>
+			</div>
+					<header>
+			<nav>
+										<div class="nav__left-container">
+							<div class="nav__button-container is-selected">
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/giveaways/new">
+											<i class="icon-green fa fa-fw fa-plus-circle"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Create a New Giveaway</p>
+												<p class="nav__row__summary__description">Get started with a new giveaway.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/giveaways/wishlist">
+											<i class="icon-blue fa fa-fw fa-users"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Community Wishlist</p>
+												<p class="nav__row__summary__description">Search for new games to share.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/giveaways/created">
+											<i class="icon-grey fa fa-fw fa-gift"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Created</p>
+												<p class="nav__row__summary__description">Check the status of your giveaways.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/giveaways/entered">
+											<i class="icon-red fa fa-fw fa-tag"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Entered</p>
+												<p class="nav__row__summary__description">Browse your giveaway entries.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/giveaways/won">
+											<i class="icon-yellow fa fa-fw fa-trophy"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Won</p>
+												<p class="nav__row__summary__description">Leave feedback for gifts you've won.</p>
+											</div>
+										</a>							
+									</div>
+								</div>	
+								<a class="nav__button nav__button--is-dropdown" href="/">Giveaways</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+							</div>
+														<div class="nav__button-container">
+								<a class="nav__button" href="/discussions/deals">Deals</a>
+							</div>
+							<div class="nav__button-container">
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/discussions/new">
+											<i class="icon-green fa fa-fw fa-plus-circle"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Create a New Discussion</p>
+												<p class="nav__row__summary__description">Start a topic on the forum.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/discussions/bookmarked">
+											<i class="icon-blue fa fa-fw fa-bookmark"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Bookmarked</p>
+												<p class="nav__row__summary__description">See the discussions you bookmarked.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/discussions/created">
+											<i class="icon-grey fa fa-fw fa-edit"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">View Created</p>
+												<p class="nav__row__summary__description">Check the status of your discussions.</p>
+											</div>
+										</a>
+									</div>
+								</div>	
+								<a class="nav__button nav__button--is-dropdown" href="/discussions/subscribed">Discussions</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+							</div>
+							<div class="nav__button-container">
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/support/tickets/new">
+											<i class="icon-green fa fa-fw fa-plus-circle"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Create a New Ticket</p>
+												<p class="nav__row__summary__description">Start a support ticket.</p>
+											</div>
+										</a>							
+									</div>
+								</div>	
+								<a class="nav__button nav__button--is-dropdown" href="/support">Support</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+							</div>
+														<div class="nav__button-container">
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/about/guidelines">
+											<i class="icon-blue fa fa-fw fa-file-text-o"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Guidelines</p>
+												<p class="nav__row__summary__description">Community rules and guidelines.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/about/faq">
+											<i class="icon-grey fa fa-fw fa-question-circle"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">FAQ</p>
+												<p class="nav__row__summary__description">Frequently asked questions.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/about/comment-formatting">
+											<i class="icon-red fa fa-fw fa-code"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Comment Formatting</p>
+												<p class="nav__row__summary__description">Syntax for writing comments.</p>
+											</div>
+										</a>
+									</div>
+								</div>	
+								<a class="nav__button nav__button--is-dropdown" href="/about/faq">Help</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+							</div>
+						</div>
+						<div class="nav__right-container">
+														<div class="nav__button-container nav__button-container--notification nav__button-container--inactive">
+								<a title="Giveaways Created" class="nav__button" href="/giveaways/created"><i class="fa fa-gift"></i></a>
+							</div>
+														<div class="nav__button-container nav__button-container--notification nav__button-container--inactive">
+								<a title="Giveaways Won" class="nav__button" href="/giveaways/won"><i class="fa fa-trophy"></i></a>
+							</div>
+							<div class="nav__button-container nav__button-container--notification nav__button-container--inactive">
+								<a title="Messages" class="nav__button" href="/messages"><i class="fa fa-envelope"></i></a>
+							</div>
+														<div class="nav__button-container">
+								<a class="nav__button nav__button--is-dropdown" href="/account">Account (<span class="nav__points">400</span>P / <span title="7.25">Level 7</span>)</a>
+								<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+								<div class="nav__relative-dropdown is-hidden">
+									<div class="nav__absolute-dropdown">
+										<a class="nav__row" href="/account/settings/profile">
+											<i class="icon-green fa fa-fw fa-refresh"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Sync with Steam</p>
+												<p class="nav__row__summary__description">Last synced <span data-timestamp="1784161332">2 days</span> ago.</p>
+											</div>
+										</a>
+										<a class="nav__row" href="/stats">
+											<i class="icon-grey fa fa-fw fa-bar-chart"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">My Stats</p>
+												<p class="nav__row__summary__description">Learn more about your activity.</p>
+											</div>
+										</a>
+										<div class="nav__row is-clickable js__logout" data-form="do=logout&xsrf_token=8963e09cc778b961fab829c95b94de39">
+											<i class="icon-blue fa fa-fw fa-sign-out"></i>
+											<div class="nav__row__summary">
+												<p class="nav__row__summary__name">Logout</p>
+												<p class="nav__row__summary__description">Sign-out of your account.</p>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="nav__button-container nav__button-container--notification">
+								<a href="/user/TestUser" class="nav__avatar-outer-wrap">
+									<div class="nav__avatar-inner-wrap" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></div>
+								</a>
+							</div>
+						</div>
+									</nav>
+		</header>
+				<div class="popup popup--hide-games">
+			<i class="popup__icon fa fa-eye-slash"></i>
+			<p class="popup__heading">Would you like to hide all giveaways<br />for <span class="popup__heading__bold"></span>?</p>
+			<form method="post">
+				<input type="hidden" name="xsrf_token" value="deadbeefdeadbeefdeadbeefdeadbeef" />
+				<input type="hidden" name="game_id" value="" />
+				<input type="hidden" name="do" value="hide_giveaways_by_game_id" />
+				<div data-enabled="1" class="form__submit-button js__submit-hide-games"><i class="fa fa-check-circle"></i> Yes</div>
+				<div class="form__saving-button is-hidden is-disabled"><i class="fa fa-refresh fa-spin"></i> Please wait...</div>
+			</form>
+						<p class="popup__actions">
+				<a href="/account/settings/giveaways/filters">View Hidden Games</a>
+				<span class="b-close">Close</span>
+			</p>
+		</div>
+					<div class="featured__container">
+				<div class="featured__outer-wrap featured__outer-wrap--home" style="background-color: rgb(20,40,89);">
+					<div class="featured__inner-wrap">
+						<a href="/giveaway/2vyBp/seed-world" class="global__image-outer-wrap global__image-outer-wrap--game-xlarge"><img src="https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/3768080/445b05b71b767f2f799493fafd5582732041c34b/header.jpg?t=1782652245" /></a>
+						
+						<div class="featured__summary">
+							<div class="featured__heading">
+								<div class="featured__heading__medium"><a href="/giveaway/2vyBp/seed-world">Seed World</a></div>
+								
+								<div class="featured__heading__small">(3P)</div>
+							</div>
+							<div class="featured__columns">				
+								<div class="featured__column"><i style="color:rgb(102,131,204);" class="fa fa-clock-o"></i> <span data-timestamp="1784381460">16 minutes</span> remaining</div>
+								<div class="featured__column featured__column--width-fill text-right"><span data-timestamp="1784370985">2 hours</span> ago by <a style="color:rgb(102,131,204);" href="/user/severesp">severesp</a></div><a href="/user/severesp" class="featured_giveaway_image_avatar" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+						</div>					</div>
+				</div>
+			</div>
+				<div class="page__outer-wrap">
+		<div class="page__inner-wrap">
+			<div class="widget-container">
+				<div class="sidebar" style="width: 300px; min-width: 300px;">
+					
+				<div class="sidebar__search-container">
+					<input class="sidebar__search-input" name="search-query" type="text" placeholder="Search..." value="xkcdnonexistentgame42" />
+					<i class="fa fa-search"></i>
+				</div>
+				<div class="sidebar__heading">Browse</div><ul class="sidebar__navigation">
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item is-selected"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/"><i class="fa fa-caret-right"></i> 
+									<div class="sidebar__navigation__item__name">All</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?type=wishlist">
+									<div class="sidebar__navigation__item__name">Wishlist</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?type=recommended">
+									<div class="sidebar__navigation__item__name">Recommended</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?copy_min=2">
+									<div class="sidebar__navigation__item__name">Multiple Copies</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?dlc=true">
+									<div class="sidebar__navigation__item__name">DLC</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?type=group">
+									<div class="sidebar__navigation__item__name">Group</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/search?type=new">
+									<div class="sidebar__navigation__item__name">New</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li></ul><div class="sidebar__heading">My Giveaways</div><ul class="sidebar__navigation">
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/created">
+									<div class="sidebar__navigation__item__name">Created</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/entered">
+									<div class="sidebar__navigation__item__name">Entered</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaways/won">
+									<div class="sidebar__navigation__item__name">Won</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li></ul><div class="xiyplq"><a style=" margin: 25px 0 0 0;" class="fanatical_container hide vertical" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Feven-steamier-sakura-special"><img class="fanatical_img" src="https://hb.imgix.net/6c3944173e6d9ac9293ee5ed0850c725c3a819f9.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=ed3c1db4d08a0b65262c45a27414a9eb" /><div class="fanatical_description"><div><span class="fanatical_new">New</span> <span class="fanatical_name">Even Steamier Sakura Special</span></div><div class="fanatical_date"><i class="fa fa-clock-o"></i><div>Started <span data-timestamp="1784311200">19 hours</span> ago</div></div></div><div class="fanatical_summary"><div class="fanatical_icons"><div class="fanatical_icon" style="background-image: url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div></div><div class="fanatical_pricing">$9.00</div></div></a>
+						<div style="padding-top: 35px;">
+							<!-- sg_homepage_top_responsive -->
+							<ins class="adsbygoogle"
+								 style="display:block"
+								 data-ad-client="ca-pub-7519145598166360"
+								 data-ad-slot="3652115722"
+								 data-ad-format="auto"
+								 data-full-width-responsive="true"></ins>
+							<script nonce="uURbx5JWOI6cbItR2OB5FA==">
+								 (adsbygoogle = window.adsbygoogle || []).push({});
+							</script>
+						</div>
+					</div>				</div>
+				<div>
+											<div class="pinned-giveaways-header">
+								<div class="pinned-giveaways-tab">Featured</div>
+								<div class="pinned-giveaways-expand" data-more="1">Show 1 More</div>							</div>
+							<div class="pinned-giveaways">
+								
+			<div class="giveaway__row-outer-wrap" data-game-id="4230427583">
+				<div class="giveaway__row-inner-wrap has-description">
+					<div class="giveaway__summary">
+						<h2 class="giveaway__heading">
+							<a class="giveaway__heading__name" href="/giveaway/Qzajs/lofi-cozy-room">Lofi Cozy Room</a><span class="giveaway__heading__thin">(100 Copies)</span><span class="giveaway__heading__thin">(0P)</span><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-steam&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Steam Store&quot;}]}]}" class="giveaway__icon" rel="nofollow noopener" target="_blank" href="https://store.steampowered.com/app/4621450?utm_source=SteamGifts"><i class="fa fa-fw fa-steam"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-camera&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Screenshots / Videos&quot;}]}]}" data-lightbox-id="4230427583" class="giveaway__icon fa fa-fw fa-camera"></i><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-search&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;More Giveaways&quot;}]}]}" title="Free Steam Giveaways and Keys for Lofi Cozy Room" class="giveaway__icon" href="/game/Q3v6M/lofi-cozy-room"><i class="fa fa-fw fa-search"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-eye-slash&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Hide Giveaways&quot;}]}]}" data-popup="popup--hide-games" class="giveaway__icon giveaway__hide trigger-popup fa fa-fw fa-eye-slash"></i>
+						</h2>
+						<div class="giveaway__columns">
+							<div><i class="fa fa-clock-o"></i> <span data-timestamp="1784722920">3 days</span> remaining</div><div class="giveaway__column--width-fill text-right"><span data-timestamp="1782131445">3 weeks</span> ago by <a class="giveaway__username" href="/user/JANNER66">JANNER66</a></div></div>
+							<div class="giveaway__links">
+								<a href="/giveaway/Qzajs/lofi-cozy-room/entries"><span>3,521 entries</span></a>
+								<a href="/giveaway/Qzajs/lofi-cozy-room"><span>20 comments</span></a>
+							</div>
+						</div><div class="giveaway__quick-entry-wrap"><div data-code="Qzajs" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--description" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-align-left&quot;,&quot;color&quot;:&quot;var(--color-blue-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;View Description&quot;}]}]}"><i class="fa fa-align-left"></i></div><form class="giveaway__quick-entry-form"><input type="hidden" name="xsrf_token" value="deadbeefdeadbeefdeadbeefdeadbeef" /><input type="hidden" name="do" value="" /><input type="hidden" name="code" value="Qzajs" /><div data-do="entry_insert" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--insert is-locked" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-plus-circle&quot;,&quot;color&quot;:&quot;var(--color-green-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Enter Giveaway&quot;}]}]}"><i class="fa fa-plus-circle"></i></div><div data-do="entry_delete" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--delete" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-minus-circle&quot;,&quot;color&quot;:&quot;var(--color-yellow-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Remove Entry&quot;}]}]}"><i class="fa fa-minus-circle"></i></div></form></div><a href="/user/JANNER66" class="giveaway_image_avatar" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a><a class="giveaway_image_thumbnail" style="background-image:url(https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4621450/f4144f7cb8364c3cbe51502b1166678ac2fb7f63/capsule_184x69.jpg?t=1782192412);" href="/giveaway/Qzajs/lofi-cozy-room"></a>
+				</div>
+			</div>
+			<div class="giveaway__row-outer-wrap" data-game-id="4230384948">
+				<div class="giveaway__row-inner-wrap has-description">
+					<div class="giveaway__summary">
+						<h2 class="giveaway__heading">
+							<a class="giveaway__heading__name" href="/giveaway/T9bUz/sex-game-bdsm-episode-1">Sex Game - BDSM - Episode 1</a><span class="giveaway__heading__thin">(50 Copies)</span><span class="giveaway__heading__thin">(5P)</span><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-steam&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Steam Store&quot;}]}]}" class="giveaway__icon" rel="nofollow noopener" target="_blank" href="https://store.steampowered.com/app/4116410?utm_source=SteamGifts"><i class="fa fa-fw fa-steam"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-camera&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Screenshots / Videos&quot;}]}]}" data-lightbox-id="4230384948" class="giveaway__icon fa fa-fw fa-camera"></i><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-search&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;More Giveaways&quot;}]}]}" title="Free Steam Giveaways and Keys for Sex Game - BDSM - Episode 1" class="giveaway__icon" href="/game/gOe2d/sex-game-bdsm-episode-1"><i class="fa fa-fw fa-search"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-eye-slash&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Hide Giveaways&quot;}]}]}" data-popup="popup--hide-games" class="giveaway__icon giveaway__hide trigger-popup fa fa-fw fa-eye-slash"></i>
+						</h2>
+						<div class="giveaway__columns">
+							<div><i class="fa fa-clock-o"></i> <span data-timestamp="1784581140">2 days</span> remaining</div><div class="giveaway__column--width-fill text-right"><span data-timestamp="1782558983">3 weeks</span> ago by <a class="giveaway__username" href="/user/EroticGamesClub">EroticGamesClub</a></div></div>
+							<div class="giveaway__links">
+								<a href="/giveaway/T9bUz/sex-game-bdsm-episode-1/entries"><span>2,581 entries</span></a>
+								<a href="/giveaway/T9bUz/sex-game-bdsm-episode-1"><span>1 comment</span></a>
+							</div>
+						</div><div class="giveaway__quick-entry-wrap"><div data-code="T9bUz" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--description" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-align-left&quot;,&quot;color&quot;:&quot;var(--color-blue-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;View Description&quot;}]}]}"><i class="fa fa-align-left"></i></div><form class="giveaway__quick-entry-form"><input type="hidden" name="xsrf_token" value="deadbeefdeadbeefdeadbeefdeadbeef" /><input type="hidden" name="do" value="" /><input type="hidden" name="code" value="T9bUz" /><div data-do="entry_insert" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--insert is-locked" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-plus-circle&quot;,&quot;color&quot;:&quot;var(--color-green-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Enter Giveaway&quot;}]}]}"><i class="fa fa-plus-circle"></i></div><div data-do="entry_delete" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--delete" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-minus-circle&quot;,&quot;color&quot;:&quot;var(--color-yellow-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Remove Entry&quot;}]}]}"><i class="fa fa-minus-circle"></i></div></form></div><a href="/user/EroticGamesClub" class="giveaway_image_avatar" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a><a class="giveaway_image_thumbnail" style="background-image:url(https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4116410/09a9126bee9e3e8aea624bbf83e6765ae503f6c1/capsule_184x69.jpg?t=1762512469);" href="/giveaway/T9bUz/sex-game-bdsm-episode-1"></a>
+				</div>
+			</div>
+			<div class="giveaway__row-outer-wrap" data-game-id="4230380656">
+				<div class="giveaway__row-inner-wrap has-description">
+					<div class="giveaway__summary">
+						<h2 class="giveaway__heading">
+							<a class="giveaway__heading__name" href="/giveaway/GdMBH/sex-game-naughty-couple-episode-8">Sex Game - Naughty Couple -...</a><span class="giveaway__heading__thin">(50 Copies)</span><span class="giveaway__heading__thin">(5P)</span><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-steam&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Steam Store&quot;}]}]}" class="giveaway__icon" rel="nofollow noopener" target="_blank" href="https://store.steampowered.com/app/4073210?utm_source=SteamGifts"><i class="fa fa-fw fa-steam"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-camera&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Screenshots / Videos&quot;}]}]}" data-lightbox-id="4230380656" class="giveaway__icon fa fa-fw fa-camera"></i><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-search&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;More Giveaways&quot;}]}]}" title="Free Steam Giveaways and Keys for Sex Game - Naughty Couple - Episode 8" class="giveaway__icon" href="/game/eeKqF/sex-game-naughty-couple-episode-8"><i class="fa fa-fw fa-search"></i></a><i data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-eye-slash&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Hide Giveaways&quot;}]}]}" data-popup="popup--hide-games" class="giveaway__icon giveaway__hide trigger-popup fa fa-fw fa-eye-slash"></i>
+						</h2>
+						<div class="giveaway__columns">
+							<div><i class="fa fa-clock-o"></i> <span data-timestamp="1784408340">7 hours</span> remaining</div><div class="giveaway__column--width-fill text-right"><span data-timestamp="1782378697">3 weeks</span> ago by <a class="giveaway__username" href="/user/EroticGamesClub">EroticGamesClub</a></div></div>
+							<div class="giveaway__links">
+								<a href="/giveaway/GdMBH/sex-game-naughty-couple-episode-8/entries"><span>2,847 entries</span></a>
+								<a href="/giveaway/GdMBH/sex-game-naughty-couple-episode-8"><span>4 comments</span></a>
+							</div>
+						</div><div class="giveaway__quick-entry-wrap"><div data-code="GdMBH" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--description" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-align-left&quot;,&quot;color&quot;:&quot;var(--color-blue-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;View Description&quot;}]}]}"><i class="fa fa-align-left"></i></div><form class="giveaway__quick-entry-form"><input type="hidden" name="xsrf_token" value="deadbeefdeadbeefdeadbeefdeadbeef" /><input type="hidden" name="do" value="" /><input type="hidden" name="code" value="GdMBH" /><div data-do="entry_insert" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--insert is-locked" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-plus-circle&quot;,&quot;color&quot;:&quot;var(--color-green-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Enter Giveaway&quot;}]}]}"><i class="fa fa-plus-circle"></i></div><div data-do="entry_delete" class="giveaway__quick-entry-btn giveaway__quick-entry-btn--delete" data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot;:[{&quot;class&quot;:&quot;fa-minus-circle&quot;,&quot;color&quot;:&quot;var(--color-yellow-3)&quot;}],&quot;columns&quot;:[{&quot;name&quot;:&quot;Remove Entry&quot;}]}]}"><i class="fa fa-minus-circle"></i></div></form></div><a href="/user/EroticGamesClub" class="giveaway_image_avatar" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a><a class="giveaway_image_thumbnail" style="background-image:url(https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/4073210/c3b742d45195128e9668ae2d89fc901208d51042/capsule_184x69.jpg?t=1760340742);" href="/giveaway/GdMBH/sex-game-naughty-couple-episode-8"></a>
+				</div>
+			</div>							</div>
+													<div class="page__heading">
+							<div class="page__heading__breadcrumbs"><a href="/">Giveaways</a><i class="fa fa-angle-right"></i><a href="/giveaways/search?q=xkcdnonexistentgame42">Searching &#039;xkcdnonexistentgame42&#039;</a></div>								<a href="/account/settings/giveaways">
+									<i class="fa fa-cog"></i>
+								</a>
+														</div>
+						<div class="pagination pagination--no-results"><div class="pagination__results">No results were found.</div></div>						<div class="widget-container widget-container--margin-top" style="margin-top: 50px;">
+							<div class="widget-container">
+								<div>
+									<div class="block_header">
+										<a href="/discussions/deals" class="block_header_text">Deals</a>
+										<a href="/discussions/deals" class="block_header_link">View More</a>
+									</div>
+									<div class="table">
+										<div class="table__rows">
+											
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Formidolosus" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/zIYa7/humble-bundle-2k-megahits-2026-bundle">[Humble Bundle] 2k Megahits 2026 Bundle🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/zIYa7/humble-bundle-2k-megahits-2026-bundle">24 Comments</a> - Last post <span data-timestamp="1784378384">34 minutes</span> ago by <a class="table__column__secondary-link" href="/user/MarvaEZ">MarvaEZ</a><a class="icon-green table__last-comment-icon" href="/go/comment/1yW1vno"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Janediel" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/nlJIt/the-life-and-suffering-of-sir-brante-is-free-on-steam-and-gog">The Life and Suffering of Sir Brante is free on...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/nlJIt/the-life-and-suffering-of-sir-brante-is-free-on-steam-and-gog">16 Comments</a> - Last post <span data-timestamp="1784376650">1 hour</span> ago by <a class="table__column__secondary-link" href="/user/Protatoes">Protatoes</a><a class="icon-green table__last-comment-icon" href="/go/comment/6XlBcx9"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Formidolosus" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/pNPjg/humble-bundle-even-steamier-sakura-special">[Humble Bundle] Even Steamier Sakura Special 🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/pNPjg/humble-bundle-even-steamier-sakura-special">20 Comments</a> - Last post <span data-timestamp="1784375728">1 hour</span> ago by <a class="table__column__secondary-link" href="/user/PunishedStig">PunishedStig</a><a class="icon-green table__last-comment-icon" href="/go/comment/ls1a9sy"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/sensualshakti" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/Hj3qx/humble-bundle-may-2024-humble-choice-54-bravery-mediterranea-out-of-stock">[Humble Bundle] May 2024 Humble Choice (#54) 💜 ...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Hj3qx/humble-bundle-may-2024-humble-choice-54-bravery-mediterranea-out-of-stock">417 Comments</a> - Last post <span data-timestamp="1784373816">1 hour</span> ago by <a class="table__column__secondary-link" href="/user/ComNguoi">ComNguoi</a><a class="icon-green table__last-comment-icon" href="/go/comment/mc19dQ0"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/bttr" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/Hyzbb/steam-kairosoft-30th-anniversary-8-steam-bundles-final">[Steam] Kairosoft 30th Anniversary - 8 Steam bu...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Hyzbb/steam-kairosoft-30th-anniversary-8-steam-bundles-final">37 Comments</a> - Last post <span data-timestamp="1784372864">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/TWayne">TWayne</a><a class="icon-green table__last-comment-icon" href="/go/comment/Ug1sEYY"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Formidolosus" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/UBxEd/fanatical-build-your-own-best-of-cozy-bundle">[Fanatical] Build your own Best of Cozy Bundle 🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/UBxEd/fanatical-build-your-own-best-of-cozy-bundle">9 Comments</a> - Last post <span data-timestamp="1784371305">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/Chris76de">Chris76de</a><a class="icon-green table__last-comment-icon" href="/go/comment/6vlaQLE"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/MeguminShiro" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/Jd9T4/info-humble-bundlekey-expiration-info-list260621">[INFO]【📦 Humble Bundle】Key Expiration Info List...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Jd9T4/info-humble-bundlekey-expiration-info-list260621">107 Comments</a> - Last post <span data-timestamp="1784366566">3 hours</span> ago by <a class="table__column__secondary-link" href="/user/ImpAtience">ImpAtience</a><a class="icon-green table__last-comment-icon" href="/go/comment/xTmSaBl"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+														</div>
+									</div>
+								</div>
+							</div>
+							<div class="widget-container">
+								<div>
+									<div class="block_header">
+										<a href="/discussions" class="block_header_text">Discussions</a>
+										<a href="/discussions" class="block_header_link">View More</a>
+									</div>
+									<div class="table">
+										<div class="table__rows">
+											
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/abdNiszan" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/2qkfv/no-reason-event-current-game-dustwind">No reason event | Current Game - [Dustwind]</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/2qkfv/no-reason-event-current-game-dustwind">51 Comments</a> - Last post <span data-timestamp="1784380394">1 minute</span> ago by <a class="table__column__secondary-link" href="/user/abdNiszan">abdNiszan</a><a class="icon-green table__last-comment-icon" href="/go/comment/BH8QfqW"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/HustlaOG" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/GQ8Sn/official-last-movie-you-saw-thread">Official last movie you saw thread</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/GQ8Sn/official-last-movie-you-saw-thread">11,035 Comments</a> - Last post <span data-timestamp="1784380355">1 minute</span> ago by <a class="table__column__secondary-link" href="/user/ba2">ba2</a><a class="icon-green table__last-comment-icon" href="/go/comment/xTtOdr7"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/HardWorkingLoner" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/RBIyt/bundle-price-split-publishercharitybundle-site">Bundle price split (publisher/charity/bundle site)</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/RBIyt/bundle-price-split-publishercharitybundle-site">1 Comments</a> - Last post <span data-timestamp="1784380240">3 minutes</span> ago by <a class="table__column__secondary-link" href="/user/wigglenose">wigglenose</a><a class="icon-green table__last-comment-icon" href="/go/comment/DrJpNhs"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/cg" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/M9UFV/upcoming-autojoin-suspensions">Upcoming AutoJoin Suspensions</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/M9UFV/upcoming-autojoin-suspensions">1,344 Comments</a> - Last post <span data-timestamp="1784380200">4 minutes</span> ago by <a class="table__column__secondary-link" href="/user/CakeGremlin">CakeGremlin</a><a class="icon-green table__last-comment-icon" href="/go/comment/hbrOnEV"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/Zumzoom" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/79wXh/gog-discount-codes-lets-share">[GOG] Discount codes - lets share!</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/79wXh/gog-discount-codes-lets-share">5,624 Comments</a> - Last post <span data-timestamp="1784379770">11 minutes</span> ago by <a class="table__column__secondary-link" href="/user/ba2">ba2</a><a class="icon-green table__last-comment-icon" href="/go/comment/5GiOXeV"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/DancingXmas" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/Bcrnx/07-xmas-year-round-summer-break-july-2026-1010-giveaways">[07] Xmas Year Round - Summer Break July 2026 [...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Bcrnx/07-xmas-year-round-summer-break-july-2026-1010-giveaways">341 Comments</a> - Last post <span data-timestamp="1784379649">13 minutes</span> ago by <a class="table__column__secondary-link" href="/user/msboring27">msboring27</a><a class="icon-green table__last-comment-icon" href="/go/comment/FJjpIG4"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/X37" style="background-image:url(https://avatars.steamstatic.com/0000000000000000000000000000000000000000_medium.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/tvIFu/does-this-count-to-level">Does this count to level?!?</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/tvIFu/does-this-count-to-level">42 Comments</a> - Last post <span data-timestamp="1784379453">16 minutes</span> ago by <a class="table__column__secondary-link" href="/user/DeliberateTaco">DeliberateTaco</a><a class="icon-green table__last-comment-icon" href="/go/comment/bUxRgDN"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+														</div>
+									</div>
+								</div>
+							</div>
+						</div>
+														<div class="widget-container widget-container--margin-top" style="margin-top: 50px;">
+									<div>
+										<div class="block_header">
+											<div class="block_header_text">New Bundles</div>
+										</div>
+										<div class="table">
+											<div class="table__rows">
+																									<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Feven-steamier-sakura-special&amp;product_id=5a82902da32c5411732f469a8a7d23c2">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/6c3944173e6d9ac9293ee5ed0850c725c3a819f9.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=ed3c1db4d08a0b65262c45a27414a9eb');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="fanatical_new">New</span> <span class="homepage_table_column_heading">Even Steamier Sakura Special</span></p>
+																<div>Started <span data-timestamp="1784311200">19 hours</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$9.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2F2k-megahits-2026-bundle&amp;product_id=a40c8c78f45e74570f9e1cc989d66385">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/2ba4b565d865609b7e7e07e1302eff32629b0226.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=f18e2210926096360dc0432f148ca5bc');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="fanatical_new">New</span> <span class="homepage_table_column_heading">2K Megahits 2026 Bundle</span></p>
+																<div>Started <span data-timestamp="1784311200">19 hours</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$15.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Fliminal-spaces&amp;product_id=e7c4f126101095b4c6dd568202862335">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/15e37e03f1c809f954f11f62c79ab52281cdd9db.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=2f29f270980b75d2720660abb26328b2');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Liminal Spaces</span></p>
+																<div>Started <span data-timestamp="1784138400">2 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$10.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Fhandhelds-bundle&amp;product_id=013e28e2c90f1e91814d1bea76f80011">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/b3359ab45da0cb979a5ab3e3a37c265ab43a35d4.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=bda1873177856b1d645f9a935856c6fe');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Humble Handhelds Bundle</span></p>
+																<div>Started <span data-timestamp="1784138400">2 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$5.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2Fsquad-goals&amp;product_id=5cc128852ffeb6e5991aca158bf531c0">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/humble_bundle_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://hb.imgix.net/134420897b49298e25bfbfbfe894b21c1f024ddd.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=9354924a51bd0d0d56ae326ee931609e');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Squad Goals</span></p>
+																<div>Started <span data-timestamp="1783706400">1 week</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$10.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fbundle%2Fpremiere-bundle&amp;product_id=e32bd04db5fdd0ef921c5a94c728d455">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/89d8dca1-e7d0-47d2-95d3-24ec29d096ac.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="fanatical_new">New</span> <span class="homepage_table_column_heading">Premiere Bundle</span></p>
+																<div>Started <span data-timestamp="1784293200">1 day</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$9.99</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fpick-and-mix%2Fbuild-your-own-best-of-tabletop-bundle&amp;product_id=1b0872a9a0da0a10f191e973fe72f561">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/67aeb835-11be-485e-8ed5-f530ea1e78ad.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Build your own Best of Tabletop Bundle</span></p>
+																<div>Started <span data-timestamp="1784206800">2 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$8.99</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fbundle%2F50-game-changing-sound-fx-collection&amp;product_id=449ea49cbe73a0add5d3fdd40a72460c">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/090f34bd-eb61-46e6-862a-a9328735f45b.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">50 Game Changing Sound FX Collection</span></p>
+																<div>Started <span data-timestamp="1784192400">2 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$1.00</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fpick-and-mix%2Fbuild-your-own-best-of-bento-bundle&amp;product_id=446896e1ba601c479fb702dbb62b4671">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/d37c545f-e70c-4a58-87a7-9bd7d1b5bfad.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Build your own Best of Bento Bundle (2026)</span></p>
+																<div>Started <span data-timestamp="1784120400">3 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$9.99</span>
+															</div>
+														</a>
+													</div>
+																										<div class="table__row-outer-wrap">
+														<a class="table__row-inner-wrap" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fpick-and-mix%2Fbuild-your-own-best-of-cozy-bundle&amp;product_id=63262b3a2f75fc2df4fa235392aa4ace">
+															<div>
+																<div class="table_image_thumbnail" style="width: 20px; height: 20px; background-image:url('https://cdn.steamgifts.com/img/fanatical_icon.png');"></div>
+															</div>
+															<div>
+																<div class="table_image_thumbnail" style="background-image:url('https://fanatical.imgix.net/product/original/beaa2698-007f-4df2-bcd3-be9719a7da70.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200');"></div>
+															</div>
+
+															<div class="table__column--width-fill">
+																<p><span class="homepage_table_column_heading">Build your own Best of Cozy Bundle</span></p>
+																<div>Started <span data-timestamp="1784034000">4 days</span> ago</div>															</div>
+															<div>
+																<span class="fanatical_pricing">$5.55</span>
+															</div>
+														</a>
+													</div>
+																								</div>
+										</div>
+									</div>
+								</div>
+												</div>
+			</div>
+		</div>
+	</div>
+		<footer>
+			<div class="footer_inner_wrap">
+				<div class="footer_columns">
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-gift"></i>
+							<div class="footer_column_name">SteamGifts</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/">Giveaways</a>
+							<a class="footer_column_link" href="/discussions/deals">Deals</a>
+							<a class="footer_column_link" href="/discussions">Discussions</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-file-text-o"></i>
+							<div class="footer_column_name">Browse</div>
+						</div>
+						<div class="footer_column_links">
+														<a class="footer_column_link" href="/stats">Community Stats</a>
+														<a class="footer_column_link" href="/archive">Giveaway Archive</a>
+							<a class="footer_column_link" href="/roles">User Roles</a>
+							<a class="footer_column_link" href="/users">User List</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-question-circle"></i>
+							<div class="footer_column_name">Help</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/about/guidelines">Guidelines</a>
+							<a class="footer_column_link" href="/about/faq">FAQ</a>
+							<a class="footer_column_link" href="/about/comment-formatting">Comment Formatting</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-gavel"></i>
+							<div class="footer_column_name">Legal</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/legal/privacy-policy">Privacy Policy</a>
+							<a class="footer_column_link" href="/legal/cookie-policy">Cookie Policy</a>
+							<a class="footer_column_link" href="/legal/terms-of-service">Terms of Service</a>
+						</div>
+					</div>
+				</div>
+				<div class="footer_lower">
+					<div class="footer_steam">
+						<div>Powered by</div>
+						<a class="footer_steam_logo" href="https://store.steampowered.com" target="_blank" rel="nofollow noopener">
+							<i class="fa fa-steam"></i>
+							<div>Steam</div>
+						</a>
+					</div>
+					<div class="footer_sites">
+						<a title="Steam Trading" href="https://www.steamtrades.com">SteamTrades.com</a>
+						<a title="Free Steam Keys and Giveaways" href="https://www.steamgifts.com">SteamGifts.com</a>
+					</div>
+				</div>
+			</div>
+		</footer>
+	<script nonce="uURbx5JWOI6cbItR2OB5FA==">(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.nonce='uURbx5JWOI6cbItR2OB5FA==';d.innerHTML="window.__CF$cv$params={r:'a1d1bffc7bfd0bc5',t:'MTc4NDM4MDQ3MQ=='};var a=document.createElement('script');a.nonce='uURbx5JWOI6cbItR2OB5FA==';a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/backend/tests/unit/test_services_giveaway_service.py
+++ b/backend/tests/unit/test_services_giveaway_service.py
@@ -10,7 +10,11 @@ from core.time import utcnow
 from models.base import Base
 from services.game_service import GameService
 from services.giveaway_service import GiveawayService
-from utils.steamgifts_client import SteamGiftsClient, SteamGiftsError
+from utils.steamgifts_client import (
+    SteamGiftsClient,
+    SteamGiftsError,
+    SteamGiftsScrapeDriftError,
+)
 
 
 # Test database setup
@@ -177,6 +181,115 @@ async def test_sync_giveaways_handles_errors(test_db, mock_sg_client, mock_game_
         # Should have synced first page only
         assert new == 1
         assert updated == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_giveaways_stops_early_on_empty_page(test_db, mock_sg_client, mock_game_service):
+    """An empty page ends the scan without fetching the remaining pages."""
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        # Page 1 is full (list may continue), page 2 is empty (end of list),
+        # so pages 3-5 must never be fetched. A short page also ends the
+        # scan; that path is covered by the unstick tests below.
+        full_page = [
+            {"code": f"GA{i:03d}", "game_name": "Test", "price": 50} for i in range(50)
+        ]
+        mock_sg_client.get_giveaways = AsyncMock(side_effect=[full_page, []])
+
+        new, updated = await service.sync_giveaways(pages=5)
+
+        assert new == 50
+        assert mock_sg_client.get_giveaways.await_count == 2  # not 5
+
+
+def _wishlist_ga(code, game_name="Wanted Game"):
+    """Scraped wishlist giveaway dict as the client returns it."""
+    return {
+        "code": code,
+        "game_name": game_name,
+        "price": 25,
+        "end_time": utcnow() + timedelta(days=1),
+        "is_wishlist": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_wishlist_unsticks_removed_games(test_db, mock_sg_client, mock_game_service):
+    """After a complete wishlist scan, active giveaways that no longer appear
+    lose the wishlist flag; expired ones keep it as history."""
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        await service.giveaway_repo.create(
+            code="GONE1", url="http://x/GONE1", game_name="Removed Game",
+            price=10, end_time=utcnow() + timedelta(days=1), is_wishlist=True,
+        )
+        await service.giveaway_repo.create(
+            code="EXPIR", url="http://x/EXPIR", game_name="Old Win",
+            price=10, end_time=utcnow() - timedelta(days=1), is_wishlist=True,
+        )
+        await session.commit()
+
+        # A short page (< 50 rows) means the complete list was seen.
+        mock_sg_client.get_giveaways = AsyncMock(return_value=[_wishlist_ga("STILL")])
+
+        await service.sync_giveaways(pages=3, giveaway_type="wishlist")
+
+        assert (await service.giveaway_repo.get_by_code("GONE1")).is_wishlist is False
+        assert (await service.giveaway_repo.get_by_code("EXPIR")).is_wishlist is True
+        assert (await service.giveaway_repo.get_by_code("STILL")).is_wishlist is True
+
+
+@pytest.mark.asyncio
+async def test_sync_wishlist_no_unstick_after_partial_scan(test_db, mock_sg_client, mock_game_service):
+    """A scan that hits the page cap mid-list (full last page) must not
+    un-stick anything — the absent giveaways may be on unscanned pages."""
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        await service.giveaway_repo.create(
+            code="GONE1", url="http://x/GONE1", game_name="Maybe Removed",
+            price=10, end_time=utcnow() + timedelta(days=1), is_wishlist=True,
+        )
+        await session.commit()
+
+        # A full page of 50: the list continues past the page cap.
+        full_page = [_wishlist_ga(f"GA{i:03d}") for i in range(50)]
+        mock_sg_client.get_giveaways = AsyncMock(return_value=full_page)
+
+        await service.sync_giveaways(pages=1, giveaway_type="wishlist")
+
+        assert (await service.giveaway_repo.get_by_code("GONE1")).is_wishlist is True
+
+
+@pytest.mark.asyncio
+async def test_sync_drift_logs_activity_and_skips_unstick(test_db, mock_sg_client, mock_game_service):
+    """Scrape drift aborts the scan, writes a warning to the activity log and
+    never un-sticks wishlist flags."""
+    from repositories.activity_log import ActivityLogRepository
+
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        await service.giveaway_repo.create(
+            code="KEEP1", url="http://x/KEEP1", game_name="Wanted",
+            price=10, end_time=utcnow() + timedelta(days=1), is_wishlist=True,
+        )
+        await session.commit()
+
+        mock_sg_client.get_giveaways = AsyncMock(
+            side_effect=SteamGiftsScrapeDriftError("markup changed", page=1)
+        )
+
+        new, updated = await service.sync_giveaways(pages=3, giveaway_type="wishlist")
+
+        assert (new, updated) == (0, 0)
+        assert (await service.giveaway_repo.get_by_code("KEEP1")).is_wishlist is True
+
+        logs = await ActivityLogRepository(session).get_all()
+        assert any("markup" in log.message for log in logs)
+        assert any(log.level == "warning" for log in logs)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_steamgifts_parser.py
+++ b/backend/tests/unit/test_steamgifts_parser.py
@@ -63,6 +63,16 @@ class TestWishlistPageFixture:
         assert parser.extract_xsrf_token(wishlist_html) == "deadbeefdeadbeefdeadbeefdeadbeef"
 
 
+class TestNoResultsMarker:
+    def test_marker_present_on_empty_search_fixture(self):
+        html = (FIXTURES / "empty_search_page.html").read_text(encoding="utf-8")
+        assert parser.has_no_results_marker(html) is True
+        assert parser.parse_giveaway_list(html) == []
+
+    def test_marker_absent_on_populated_page(self, wishlist_html):
+        assert parser.has_no_results_marker(wishlist_html) is False
+
+
 class TestParserEdgeCases:
     def test_empty_page(self):
         assert parser.parse_giveaway_list("<html><body></body></html>") == []

--- a/backend/tests/unit/test_utils_steamgifts_client.py
+++ b/backend/tests/unit/test_utils_steamgifts_client.py
@@ -285,11 +285,49 @@ async def test_get_giveaways_skips_pinned_featured_section(steamgifts_client):
 
 
 @pytest.mark.asyncio
+async def test_get_giveaways_raises_on_scrape_drift(steamgifts_client):
+    """Zero parsed rows without the no-results marker raises instead of
+    silently returning an empty list."""
+    from utils.steamgifts_client import SteamGiftsScrapeDriftError
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "<html><body><div>some unrecognizable page</div></body></html>"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    steamgifts_client._client = mock_client
+
+    with pytest.raises(SteamGiftsScrapeDriftError):
+        await steamgifts_client.get_giveaways(page=1)
+
+
+@pytest.mark.asyncio
+async def test_get_giveaways_empty_with_marker_is_fine(steamgifts_client):
+    """A legitimately empty result page returns [] without raising."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = (
+        '<html><body><div class="pagination pagination--no-results">'
+        "No results were found.</div></body></html>"
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    steamgifts_client._client = mock_client
+
+    giveaways = await steamgifts_client.get_giveaways(giveaway_type="wishlist")
+    assert giveaways == []
+
+
+@pytest.mark.asyncio
 async def test_get_giveaways_with_search(steamgifts_client):
     """Test fetching giveaways with search query."""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.text = "<html><body></body></html>"
+    mock_response.text = '<html><body><div class="pagination pagination--no-results">No results were found.</div></body></html>'
 
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_response)
@@ -772,7 +810,7 @@ class TestDLCScanning:
         """Test get_giveaways with dlc_only parameter."""
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.text = "<html><body></body></html>"
+        mock_response.text = '<html><body><div class="pagination pagination--no-results">No results were found.</div></body></html>'
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_response)
@@ -791,7 +829,7 @@ class TestDLCScanning:
         """Test get_giveaways with min_copies parameter."""
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.text = "<html><body></body></html>"
+        mock_response.text = '<html><body><div class="pagination pagination--no-results">No results were found.</div></body></html>'
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_response)
@@ -810,7 +848,7 @@ class TestDLCScanning:
         """Test get_giveaways with both dlc_only and min_copies."""
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.text = "<html><body></body></html>"
+        mock_response.text = '<html><body><div class="pagination pagination--no-results">No results were found.</div></body></html>'
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_response)

--- a/backend/tests/unit/test_workers_scanner.py
+++ b/backend/tests/unit/test_workers_scanner.py
@@ -38,7 +38,7 @@ async def test_scan_giveaways_success():
 
         mock_giveaway_service.sync_giveaways.assert_has_calls([
             call(pages=3),
-            call(pages=1, giveaway_type="wishlist"),
+            call(pages=3, giveaway_type="wishlist"),
         ])
         mock_event_manager.broadcast_event.assert_called_once()
 
@@ -185,7 +185,7 @@ async def test_scan_uses_settings_max_pages():
         assert results["pages_scanned"] == 10
         mock_giveaway_service.sync_giveaways.assert_has_calls([
             call(pages=10),
-            call(pages=1, giveaway_type="wishlist"),
+            call(pages=10, giveaway_type="wishlist"),
         ])
 
 
@@ -213,5 +213,5 @@ async def test_scan_defaults_to_3_pages():
         assert results["pages_scanned"] == 3
         mock_giveaway_service.sync_giveaways.assert_has_calls([
             call(pages=3),
-            call(pages=1, giveaway_type="wishlist"),
+            call(pages=3, giveaway_type="wishlist"),
         ])


### PR DESCRIPTION
- Drift detection: a listing page that parses to zero giveaways without SteamGifts' 'No results were found.' marker (pagination--no-results) now raises SteamGiftsScrapeDriftError instead of silently returning an empty list; the sync logs it as a warning in the activity log. Captured a real empty-search page as a sanitized fixture
- Wishlist scans now use max_scan_pages (was hardcoded 1 page) with early stop: an empty or short (<50 rows) page ends any scan, so small lists still cost a single request
- After a complete wishlist scan (end of list actually seen), active giveaways flagged is_wishlist that no longer appear lose the flag (game removed from Steam wishlist); expired rows keep the flag as history, and partial or drift-aborted scans never un-stick anything