### PR TITLE
Split giveaway status tabs into dedicated pages, add DLC listing

### DIFF
--- a/backend/src/api/routers/giveaways.py
+++ b/backend/src/api/routers/giveaways.py
@@ -153,8 +153,48 @@ async def get_wishlist_giveaways(
     Returns:
         Success response with list of wishlist giveaways
     """
-    giveaways = await giveaway_service.giveaway_repo.get_wishlist(
-        limit=limit, offset=offset,
+    giveaways = await giveaway_service.giveaway_repo.get_flagged(
+        "is_wishlist", limit=limit, offset=offset,
+        min_chance=min_chance, ending_within_minutes=ending_within,
+    )
+
+    # Enrich with game data (thumbnails, reviews)
+    giveaways = await giveaway_service.enrich_giveaways_with_game_data(giveaways)
+
+    giveaway_list = [
+        GiveawayResponse.model_validate(g).model_dump()
+        for g in giveaways
+    ]
+
+    return create_success_response(
+        data={
+            "giveaways": giveaway_list,
+            "count": len(giveaway_list),
+        }
+    )
+
+
+@router.get(
+    "/dlc",
+    response_model=dict[str, Any],
+    summary="Get DLC giveaways",
+    description="Get active giveaways from the DLC listing (DLC for games the user owns).",
+)
+async def get_dlc_giveaways(
+    giveaway_service: GiveawayServiceDep,
+    min_chance: float | None = Query(default=None, ge=0.01, le=100, description="Minimum win chance in percent"),
+    ending_within: int | None = Query(default=None, ge=1, description="Only giveaways ending within this many minutes"),
+    limit: int = Query(default=50, ge=1, le=200, description="Maximum results"),
+    offset: int = Query(default=0, ge=0, description="Number of records to skip"),
+) -> dict[str, Any]:
+    """
+    Get DLC giveaways.
+
+    Returns:
+        Success response with list of DLC giveaways
+    """
+    giveaways = await giveaway_service.giveaway_repo.get_flagged(
+        "is_dlc", limit=limit, offset=offset,
         min_chance=min_chance, ending_within_minutes=ending_within,
     )
 

--- a/backend/src/repositories/giveaway.py
+++ b/backend/src/repositories/giveaway.py
@@ -405,30 +405,35 @@ class GiveawayRepository(BaseRepository[Giveaway]):
         result = await self.session.execute(query)
         return list(result.scalars().all())
 
-    async def get_wishlist(
-        self, limit: int | None = None, offset: int | None = None,
+    async def get_flagged(
+        self, flag: str, limit: int | None = None, offset: int | None = None,
         min_chance: float | None = None, ending_within_minutes: int | None = None,
     ) -> list[Giveaway]:
         """
-        Get active wishlist giveaways.
+        Get active giveaways carrying a scan-derived flag.
 
         Args:
+            flag: Column name, "is_wishlist" or "is_dlc"
             limit: Maximum number to return
             offset: Number of records to skip
             min_chance: Minimum win chance in percent (copies/entries*100)
             ending_within_minutes: Only giveaways ending within this many minutes
 
         Returns:
-            List of wishlist giveaways that are still active (not expired)
+            List of flagged giveaways that are still active (not expired)
 
         Example:
-            >>> wishlist = await repo.get_wishlist(limit=20)
+            >>> wishlist = await repo.get_flagged("is_wishlist", limit=20)
         """
+        if flag not in ("is_wishlist", "is_dlc"):
+            raise ValueError(f"Unsupported scan flag: {flag}")
+        column = getattr(self.model, flag)
+
         now = utcnow()
         query = (
             select(self.model)
             .where(
-                self.model.is_wishlist == True,  # noqa: E712
+                column == True,  # noqa: E712
                 self.model.is_hidden == False,  # noqa: E712
                 (self.model.end_time == None) | (self.model.end_time > now),  # noqa: E711
                 *self._browse_filter_conditions(now, min_chance, ending_within_minutes),

--- a/backend/src/workers/scanner.py
+++ b/backend/src/workers/scanner.py
@@ -32,8 +32,8 @@ async def scan_giveaways() -> dict[str, Any]:
     """
     Scan SteamGifts for giveaways and sync to database (manual trigger).
 
-    Scans ``max_scan_pages`` regular pages plus one wishlist page, and emits
-    a ``scan_completed`` event.
+    Scans ``max_scan_pages`` regular pages plus the wishlist and DLC
+    listings, and emits a ``scan_completed`` event.
 
     Returns:
         Dictionary with scan results (new/updated/pages_scanned/scan_time).
@@ -59,11 +59,11 @@ async def scan_giveaways() -> dict[str, Any]:
                 pages=max_pages
             )
 
-            # Also scan wishlist giveaways so the Wishlist tab is populated by
-            # manual scans too. Uses the same page cap as the regular scan;
-            # the sync stops early at the end of the list, so small wishlists
-            # cost a single request. A wishlist failure shouldn't fail the
-            # whole scan.
+            # Also scan the wishlist and DLC listings so their pages are
+            # populated by manual scans too. Both use the same page cap as
+            # the regular scan; the sync stops early at the end of the list,
+            # so small listings cost a single request. A failure in either
+            # shouldn't fail the whole scan.
             wishlist_new = wishlist_updated = 0
             try:
                 wishlist_new, wishlist_updated = await ctx.giveaway_service.sync_giveaways(
@@ -72,12 +72,22 @@ async def scan_giveaways() -> dict[str, Any]:
             except Exception as e:
                 logger.error("scan_wishlist_failed", error=str(e))
 
+            dlc_new = dlc_updated = 0
+            try:
+                dlc_new, dlc_updated = await ctx.giveaway_service.sync_giveaways(
+                    pages=max_pages, dlc_only=True
+                )
+            except Exception as e:
+                logger.error("scan_dlc_failed", error=str(e))
+
             scan_time = (datetime.now(UTC) - start_time).total_seconds()
             results = {
                 "new": new_count,
                 "updated": updated_count,
                 "wishlist_new": wishlist_new,
                 "wishlist_updated": wishlist_updated,
+                "dlc_new": dlc_new,
+                "dlc_updated": dlc_updated,
                 "pages_scanned": max_pages,
                 "scan_time": round(scan_time, 2),
                 "skipped": False,
@@ -94,6 +104,8 @@ async def scan_giveaways() -> dict[str, Any]:
                 updated=updated_count,
                 wishlist_new=wishlist_new,
                 wishlist_updated=wishlist_updated,
+                dlc_new=dlc_new,
+                dlc_updated=dlc_updated,
                 pages=max_pages,
                 scan_time=scan_time,
             )

--- a/backend/tests/unit/test_repositories_giveaway.py
+++ b/backend/tests/unit/test_repositories_giveaway.py
@@ -139,32 +139,41 @@ async def test_get_active_ending_within_filter(test_db):
         assert codes == {"SOON", "LATER"}
 
 
+@pytest.mark.parametrize("flag", ["is_wishlist", "is_dlc"])
 @pytest.mark.asyncio
-async def test_get_wishlist_browse_filters(test_db):
-    """The wishlist listing honors min_chance and ending_within_minutes."""
+async def test_get_flagged_browse_filters(test_db, flag):
+    """The flagged listings honor min_chance and ending_within_minutes."""
     async with test_db() as session:
         repo = GiveawayRepository(session)
         now = utcnow()
 
         await repo.create(code="WSOON", game_name="A", price=10, url="http://x/1",
-                          end_time=now + timedelta(hours=2), is_wishlist=True,
+                          end_time=now + timedelta(hours=2), **{flag: True},
                           copies=1, entries=10)  # 10%
         await repo.create(code="WCROWD", game_name="B", price=10, url="http://x/2",
-                          end_time=now + timedelta(hours=2), is_wishlist=True,
+                          end_time=now + timedelta(hours=2), **{flag: True},
                           copies=1, entries=5000)  # 0.02%
         await repo.create(code="WLATER", game_name="C", price=10, url="http://x/3",
-                          end_time=now + timedelta(hours=48), is_wishlist=True,
+                          end_time=now + timedelta(hours=48), **{flag: True},
+                          copies=1, entries=10)
+        # Flagged with the other flag only: must never show up.
+        other = "is_dlc" if flag == "is_wishlist" else "is_wishlist"
+        await repo.create(code="OTHER", game_name="D", price=10, url="http://x/4",
+                          end_time=now + timedelta(hours=2), **{other: True},
                           copies=1, entries=10)
         await session.commit()
 
-        codes = {g.code for g in await repo.get_wishlist(min_chance=1.0)}
+        codes = {g.code for g in await repo.get_flagged(flag, min_chance=1.0)}
         assert codes == {"WSOON", "WLATER"}
 
-        codes = {g.code for g in await repo.get_wishlist(ending_within_minutes=360)}
+        codes = {g.code for g in await repo.get_flagged(flag, ending_within_minutes=360)}
         assert codes == {"WSOON", "WCROWD"}
 
-        codes = {g.code for g in await repo.get_wishlist(min_chance=1.0, ending_within_minutes=360)}
+        codes = {g.code for g in await repo.get_flagged(flag, min_chance=1.0, ending_within_minutes=360)}
         assert codes == {"WSOON"}
+
+        with pytest.raises(ValueError):
+            await repo.get_flagged("is_hidden")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_workers_scanner.py
+++ b/backend/tests/unit/test_workers_scanner.py
@@ -32,6 +32,8 @@ async def test_scan_giveaways_success():
         assert results["updated"] == 2
         assert results["wishlist_new"] == 5
         assert results["wishlist_updated"] == 2
+        assert results["dlc_new"] == 5
+        assert results["dlc_updated"] == 2
         assert results["pages_scanned"] == 3
         assert results["skipped"] is False
         assert "scan_time" in results
@@ -39,6 +41,7 @@ async def test_scan_giveaways_success():
         mock_giveaway_service.sync_giveaways.assert_has_calls([
             call(pages=3),
             call(pages=3, giveaway_type="wishlist"),
+            call(pages=3, dlc_only=True),
         ])
         mock_event_manager.broadcast_event.assert_called_once()
 
@@ -100,6 +103,7 @@ async def test_scan_giveaways_wishlist_failure_does_not_fail_scan():
     mock_giveaway_service.sync_giveaways.side_effect = [
         (5, 2),  # regular scan
         Exception("wishlist page error"),  # wishlist scan
+        (3, 1),  # DLC scan
     ]
 
     patcher, ctx = patch_automation_context(
@@ -115,6 +119,42 @@ async def test_scan_giveaways_wishlist_failure_does_not_fail_scan():
         assert results["updated"] == 2
         assert results["wishlist_new"] == 0
         assert results["wishlist_updated"] == 0
+        # The DLC scan still runs after a wishlist failure.
+        assert results["dlc_new"] == 3
+        assert results["dlc_updated"] == 1
+        assert results["skipped"] is False
+
+
+@pytest.mark.asyncio
+async def test_scan_giveaways_dlc_failure_does_not_fail_scan():
+    """A DLC scan error is logged but the rest of the scan still succeeds."""
+    from workers.scanner import scan_giveaways
+
+    mock_settings = MagicMock()
+    mock_settings.phpsessid = "test_session"
+    mock_settings.max_scan_pages = 3
+
+    mock_giveaway_service = AsyncMock()
+    mock_giveaway_service.sync_giveaways.side_effect = [
+        (5, 2),  # regular scan
+        (1, 0),  # wishlist scan
+        Exception("dlc page error"),  # DLC scan
+    ]
+
+    patcher, ctx = patch_automation_context(
+        "workers.scanner", mock_settings, giveaway_service=mock_giveaway_service
+    )
+
+    with patcher, patch("workers.scanner.event_manager") as mock_event_manager:
+        mock_event_manager.broadcast_event = AsyncMock()
+
+        results = await scan_giveaways()
+
+        assert results["new"] == 5
+        assert results["updated"] == 2
+        assert results["wishlist_new"] == 1
+        assert results["dlc_new"] == 0
+        assert results["dlc_updated"] == 0
         assert results["skipped"] is False
 
 

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -10,6 +10,9 @@ test.describe('Navigation', () => {
   test('sidebar links reach every page', async ({ page }) => {
     const pages: Array<[RegExp | string, RegExp]> = [
       ['Giveaways', /\/giveaways$/],
+      ['Wishlist', /\/giveaways\/wishlist$/],
+      ['DLC', /\/giveaways\/dlc$/],
+      ['Entered', /\/giveaways\/entered$/],
       ['Wins', /\/wins$/],
       ['History', /\/history$/],
       ['Analytics', /\/analytics$/],

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,10 @@ function AppContent() {
 
           {/* Main pages */}
           <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/giveaways" element={<Giveaways />} />
+          <Route path="/giveaways" element={<Giveaways status="active" />} />
+          <Route path="/giveaways/wishlist" element={<Giveaways status="wishlist" />} />
+          <Route path="/giveaways/dlc" element={<Giveaways status="dlc" />} />
+          <Route path="/giveaways/entered" element={<Giveaways status="entered" />} />
           <Route path="/wins" element={<Wins />} />
           <Route path="/history" element={<History />} />
           <Route path="/analytics" element={<Analytics />} />

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -8,6 +8,9 @@ describe('Sidebar', () => {
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Giveaways')).toBeInTheDocument();
+    expect(screen.getByText('Wishlist')).toBeInTheDocument();
+    expect(screen.getByText('DLC')).toBeInTheDocument();
+    expect(screen.getByText('Entered')).toBeInTheDocument();
     expect(screen.getByText('Wins')).toBeInTheDocument();
     expect(screen.getByText('History')).toBeInTheDocument();
     expect(screen.getByText('Analytics')).toBeInTheDocument();
@@ -20,6 +23,9 @@ describe('Sidebar', () => {
 
     expect(screen.getByText('Dashboard').closest('a')).toHaveAttribute('href', '/dashboard');
     expect(screen.getByText('Giveaways').closest('a')).toHaveAttribute('href', '/giveaways');
+    expect(screen.getByText('Wishlist').closest('a')).toHaveAttribute('href', '/giveaways/wishlist');
+    expect(screen.getByText('DLC').closest('a')).toHaveAttribute('href', '/giveaways/dlc');
+    expect(screen.getByText('Entered').closest('a')).toHaveAttribute('href', '/giveaways/entered');
     expect(screen.getByText('Wins').closest('a')).toHaveAttribute('href', '/wins');
     expect(screen.getByText('History').closest('a')).toHaveAttribute('href', '/history');
     expect(screen.getByText('Analytics').closest('a')).toHaveAttribute('href', '/analytics');
@@ -34,6 +40,6 @@ describe('Sidebar', () => {
     expect(nav).toBeInTheDocument();
 
     const listItems = screen.getAllByRole('listitem');
-    expect(listItems).toHaveLength(7);
+    expect(listItems).toHaveLength(10);
   });
 });

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,6 +2,9 @@ import { NavLink } from 'react-router';
 import {
   LayoutDashboard,
   Gift,
+  Heart,
+  Package,
+  Ticket,
   Trophy,
   History,
   BarChart3,
@@ -15,12 +18,18 @@ interface NavItem {
   path: string;
   label: string;
   icon: LucideIcon;
+  // Match the path exactly instead of as a prefix (needed for parent
+  // routes like /giveaways that have sibling sub-pages).
+  end?: boolean;
 }
 
 // Navigation items configuration
 const navItems: NavItem[] = [
   { path: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-  { path: '/giveaways', label: 'Giveaways', icon: Gift },
+  { path: '/giveaways', label: 'Giveaways', icon: Gift, end: true },
+  { path: '/giveaways/wishlist', label: 'Wishlist', icon: Heart },
+  { path: '/giveaways/dlc', label: 'DLC', icon: Package },
+  { path: '/giveaways/entered', label: 'Entered', icon: Ticket },
   { path: '/wins', label: 'Wins', icon: Trophy },
   { path: '/history', label: 'History', icon: History },
   { path: '/analytics', label: 'Analytics', icon: BarChart3 },
@@ -36,10 +45,11 @@ export function Sidebar() {
     <aside className="w-64 border-r border-gray-200 dark:border-gray-700 bg-surface-light dark:bg-surface-dark min-h-[calc(100vh-4rem)]">
       <nav className="p-4">
         <ul className="space-y-2">
-          {navItems.map(({ path, label, icon: Icon }) => (
+          {navItems.map(({ path, label, icon: Icon, end }) => (
             <li key={path}>
               <NavLink
                 to={path}
+                end={end}
                 className={({ isActive }) =>
                   clsx(
                     'flex items-center gap-3 px-4 py-2 rounded-lg transition-colors',

--- a/frontend/src/hooks/useGiveaways.ts
+++ b/frontend/src/hooks/useGiveaways.ts
@@ -17,7 +17,7 @@ export const giveawayKeys = {
  * Filter options for giveaways
  */
 export interface GiveawayFilters {
-  status?: 'active' | 'entered' | 'wishlist' | 'won';
+  status?: 'active' | 'entered' | 'wishlist' | 'dlc' | 'won';
   type?: 'game' | 'dlc' | 'bundle' | 'all';
   search?: string;
   sort?: 'end_time' | 'price' | 'discovered_at';
@@ -67,6 +67,8 @@ function buildGiveawaysEndpoint(
     endpointPath = '/api/v1/giveaways/active';
   } else if (filters.status === 'wishlist') {
     endpointPath = '/api/v1/giveaways/wishlist';
+  } else if (filters.status === 'dlc') {
+    endpointPath = '/api/v1/giveaways/dlc';
   } else if (filters.status === 'won') {
     endpointPath = '/api/v1/giveaways/won';
   }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -349,7 +349,7 @@ export function Dashboard() {
             ))}
             {(enteredData.total ?? 0) > 10 && (
               <p className="text-sm text-gray-500 dark:text-gray-400 text-center pt-2">
-                <a href="/giveaways?status=entered" className="text-primary-light hover:underline">
+                <a href="/giveaways/entered" className="text-primary-light hover:underline">
                   View all {enteredData.total} entered giveaways →
                 </a>
               </p>

--- a/frontend/src/pages/Giveaways.tsx
+++ b/frontend/src/pages/Giveaways.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { ExternalLink, Eye, EyeOff, Gift, Clock, AlertCircle, Loader2, X, Heart, Trophy, Star, Shield, ShieldAlert, EyeOff as HideIcon, MessageSquare, Percent, Users, Package } from 'lucide-react';
 import { SiSteam } from 'react-icons/si';
 import { Card, Button, Badge, Input, CardSkeleton } from '@/components/common';
-import { useInfiniteGiveaways, useEnterGiveaway, useHideGiveaway, useUnhideGiveaway, useRemoveEntry, useCheckGiveawaySafety, useHideOnSteamGifts, usePostComment, type GiveawayFilters } from '@/hooks';
+import { useInfiniteGiveaways, useEnterGiveaway, useHideGiveaway, useUnhideGiveaway, useRemoveEntry, useCheckGiveawaySafety, useHideOnSteamGifts, usePostComment } from '@/hooks';
 import { showSuccess, showError } from '@/stores/uiStore';
 import { useGiveawayFiltersStore } from '@/stores/giveawayFiltersStore';
 import type { Giveaway } from '@/types';
@@ -22,11 +22,23 @@ const stopIndex = (stops: number[], value: number | undefined, fallback: number)
   return idx === -1 ? fallback : idx;
 };
 
+export type GiveawayPageStatus = 'active' | 'wishlist' | 'dlc' | 'entered';
+
+const PAGE_TITLES: Record<GiveawayPageStatus, string> = {
+  active: 'Giveaways',
+  wishlist: 'Wishlist',
+  dlc: 'DLC',
+  entered: 'Entered',
+};
+
 /**
  * Giveaways page
- * Browse, filter, and enter giveaways
+ * Browse, filter, and enter giveaways. The status (active/wishlist/entered)
+ * comes from the route — each has its own sidebar entry; won giveaways live
+ * on the dedicated Wins page.
  */
-export function Giveaways() {
+export function Giveaways({ status = 'active' }: { status?: GiveawayPageStatus }) {
+  const title = PAGE_TITLES[status];
   // Filters persist across visits (localStorage-backed store)
   const filters = useGiveawayFiltersStore((s) => s.filters);
   const setFilters = useGiveawayFiltersStore((s) => s.setFilters);
@@ -39,7 +51,7 @@ export function Giveaways() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage
-  } = useInfiniteGiveaways(filters);
+  } = useInfiniteGiveaways({ ...filters, status });
   const enterGiveaway = useEnterGiveaway();
   const hideGiveaway = useHideGiveaway();
   const unhideGiveaway = useUnhideGiveaway();
@@ -82,10 +94,6 @@ export function Giveaways() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     setFilters({ search: searchInput });
-  };
-
-  const handleStatusFilter = (status: GiveawayFilters['status']) => {
-    setFilters({ status });
   };
 
   const handleScoreFilter = (score: number) => {
@@ -174,7 +182,7 @@ export function Giveaways() {
   if (error) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Giveaways</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{title}</h1>
         <Card>
           <div className="flex items-center gap-3 text-red-500">
             <AlertCircle size={24} />
@@ -188,7 +196,7 @@ export function Giveaways() {
   return (
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Giveaways</h1>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{title}</h1>
 
         {/* Search */}
         <form onSubmit={handleSearch} className="flex gap-2">
@@ -204,37 +212,8 @@ export function Giveaways() {
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-4">
-        <div className="flex flex-wrap gap-2">
-          <FilterButton
-            active={filters.status === 'active'}
-            onClick={() => handleStatusFilter('active')}
-          >
-            Active
-          </FilterButton>
-          <FilterButton
-            active={filters.status === 'wishlist'}
-            onClick={() => handleStatusFilter('wishlist')}
-          >
-            <Heart size={12} className="mr-1 fill-current text-pink-500" />
-            Wishlist
-          </FilterButton>
-          <FilterButton
-            active={filters.status === 'entered'}
-            onClick={() => handleStatusFilter('entered')}
-          >
-            Entered
-          </FilterButton>
-          <FilterButton
-            active={filters.status === 'won'}
-            onClick={() => handleStatusFilter('won')}
-          >
-            <Trophy size={12} className="mr-1 text-yellow-500" />
-            Won
-          </FilterButton>
-        </div>
-
         {/* Score Filter - only show for active status */}
-        {filters.status === 'active' && (
+        {status === 'active' && (
           <div className="flex items-center gap-3 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 rounded-lg">
             <Star size={16} className="text-yellow-500" />
             <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
@@ -264,7 +243,7 @@ export function Giveaways() {
         )}
 
         {/* Win Chance Filter (slider: Any, then 0.01% .. 100%) */}
-        {(filters.status === 'active' || filters.status === 'wishlist') && (
+        {(status === 'active' || status === 'wishlist' || status === 'dlc') && (
           <div className="flex items-center gap-3 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 rounded-lg">
             <Percent size={16} className="text-blue-500" />
             <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
@@ -295,7 +274,7 @@ export function Giveaways() {
         )}
 
         {/* Time Remaining Filter (slider: 5min .. 24h, last notch = Any) */}
-        {(filters.status === 'active' || filters.status === 'wishlist') && (
+        {(status === 'active' || status === 'wishlist' || status === 'dlc') && (
           <div className="flex items-center gap-3 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 rounded-lg">
             <Clock size={16} className="text-orange-500" />
             <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
@@ -326,7 +305,7 @@ export function Giveaways() {
         )}
 
         {/* Safety Filter */}
-        {filters.status === 'active' && (
+        {status === 'active' && (
           <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 rounded-lg">
             <Shield size={16} className="text-green-500" />
             <span className="text-sm text-gray-600 dark:text-gray-400">Safety:</span>
@@ -410,27 +389,6 @@ export function Giveaways() {
       )}
 
     </div>
-  );
-}
-
-interface FilterButtonProps {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}
-
-function FilterButton({ active, onClick, children }: FilterButtonProps) {
-  return (
-    <button
-      onClick={onClick}
-      className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-        active
-          ? 'bg-primary-light text-white'
-          : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
-      }`}
-    >
-      {children}
-    </button>
   );
 }
 

--- a/frontend/src/stores/giveawayFiltersStore.test.ts
+++ b/frontend/src/stores/giveawayFiltersStore.test.ts
@@ -19,7 +19,7 @@ describe('giveawayFiltersStore', () => {
 
   it('starts with default filters', () => {
     const { filters } = useGiveawayFiltersStore.getState();
-    expect(filters).toEqual({ status: 'active', limit: 20 });
+    expect(filters).toEqual({ limit: 20 });
   });
 
   it('merges partial updates', () => {
@@ -27,18 +27,18 @@ describe('giveawayFiltersStore', () => {
     useGiveawayFiltersStore.getState().setFilters({ minChance: 0.5, endingWithin: 6 });
 
     const { filters } = useGiveawayFiltersStore.getState();
-    expect(filters.status).toBe('active');
+    expect(filters.limit).toBe(20);
     expect(filters.minScore).toBe(7);
     expect(filters.minChance).toBe(0.5);
     expect(filters.endingWithin).toBe(6);
   });
 
   it('persists filters to localStorage', () => {
-    useGiveawayFiltersStore.getState().setFilters({ minScore: 8, status: 'wishlist' });
+    useGiveawayFiltersStore.getState().setFilters({ minScore: 8, safetyFilter: 'safe' });
 
     const persisted = lastPersistedState();
     expect(persisted.filters.minScore).toBe(8);
-    expect(persisted.filters.status).toBe('wishlist');
+    expect(persisted.filters.safetyFilter).toBe('safe');
   });
 
   it('does not persist the search query', () => {
@@ -56,7 +56,6 @@ describe('giveawayFiltersStore', () => {
     useGiveawayFiltersStore.getState().resetFilters();
 
     expect(useGiveawayFiltersStore.getState().filters).toEqual({
-      status: 'active',
       limit: 20,
     });
   });

--- a/frontend/src/stores/giveawayFiltersStore.ts
+++ b/frontend/src/stores/giveawayFiltersStore.ts
@@ -2,7 +2,9 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { GiveawayFilters } from '@/hooks/useGiveaways';
 
-type PersistedFilters = Omit<GiveawayFilters, 'page'>;
+// The status (active/wishlist/entered) comes from the route, not the store —
+// each status is its own page in the sidebar.
+type PersistedFilters = Omit<GiveawayFilters, 'page' | 'status'>;
 
 interface GiveawayFiltersState {
   filters: PersistedFilters;
@@ -11,17 +13,16 @@ interface GiveawayFiltersState {
 }
 
 const DEFAULT_FILTERS: PersistedFilters = {
-  status: 'active',
   limit: 20,
 };
 
 /**
  * Giveaways page filter store with localStorage persistence.
  *
- * Keeps the selected tab, score/safety/chance/time filters across visits so
- * they don't have to be re-applied every time the page is opened. The search
- * query is deliberately NOT persisted (a stale search silently filtering the
- * list is more confusing than helpful).
+ * Keeps the score/safety/chance/time filters across visits so they don't
+ * have to be re-applied every time the page is opened. The search query is
+ * deliberately NOT persisted (a stale search silently filtering the list is
+ * more confusing than helpful).
  */
 export const useGiveawayFiltersStore = create<GiveawayFiltersState>()(
   persist(
@@ -33,6 +34,19 @@ export const useGiveawayFiltersStore = create<GiveawayFiltersState>()(
     }),
     {
       name: 'giveaway-filters',
+      // v1: the selected tab (status) moved out of the store and into the
+      // route; strip it from state persisted by v0.
+      version: 1,
+      migrate: (persisted) => {
+        const state = persisted as {
+          filters?: PersistedFilters & { status?: string; search?: string };
+        };
+        if (state?.filters) {
+          delete state.filters.status;
+          delete state.filters.search;
+        }
+        return state as { filters: PersistedFilters & { search: undefined } };
+      },
       partialize: (state) => ({
         filters: { ...state.filters, search: undefined },
       }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -222,6 +222,10 @@ export interface HealthCheck {
 export interface ScanResult {
   new: number;
   updated: number;
+  wishlist_new?: number;
+  wishlist_updated?: number;
+  dlc_new?: number;
+  dlc_updated?: number;
   pages_scanned: number;
   scan_time: number;
   skipped?: boolean;


### PR DESCRIPTION
The Active/Wishlist/Entered/Won tabs on the Giveaways page become sidebar pages (/giveaways, /giveaways/wishlist, /giveaways/dlc, /giveaways/entered) rendering the same component parameterized by route; the Won tab is dropped since the Wins page already covers it. The filter store stops persisting the selected tab (the route owns it now) with a persist-version migration.

The DLC page is backed by a new GET /giveaways/dlc endpoint on a flag-generalized repository query (get_wishlist -> get_flagged), and the manual scan trigger now scans the DLC listing alongside wishlist so the page fills without waiting for an automation cycle.