### PR TITLE
Drop Dockerfile HEALTHCHECK in favor of the compose healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,9 +171,10 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # Expose port 80 (nginx serves both frontend and proxies to backend)
 EXPOSE 80
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost/api/v1/system/health || exit 1
+# No HEALTHCHECK here: OCI image format (podman's default) can't store it
+# and warns on every build. The healthcheck is defined in docker-compose.yml
+# instead; for plain `docker run`, pass --health-cmd if you want one:
+#   --health-cmd 'curl -f http://localhost/api/v1/system/health || exit 1'
 
 # Start via the entrypoint (handles optional PUID/PGID, then runs
 # supervisord which manages nginx + uvicorn)


### PR DESCRIPTION
OCI image format (podman's default) cannot store HEALTHCHECK and warned on every local build; the compose file already defines the same check and podman honors it at runtime. Plain docker run users can pass --health-cmd (documented in the Dockerfile).

(cherry picked from commit 4c9f968a6e26be466a43f002d40c95117f9f7a5b)