### PR TITLE
Fix untracked-DB stamping to initial revision so later migrations apply

### DIFF
--- a/backend/src/db/session.py
+++ b/backend/src/db/session.py
@@ -56,6 +56,12 @@ async def get_db() -> AsyncGenerator[AsyncSession]:
             await session.close()
 
 
+# Revision id of the initial schema migration (93fe35470006_initial_schema.py).
+# Untracked databases predating Alembic are stamped here so later migrations
+# still apply.
+_INITIAL_REVISION = "93fe35470006"
+
+
 async def init_db() -> None:
     """
     Initialize the database by running Alembic migrations.
@@ -64,12 +70,12 @@ async def init_db() -> None:
     Uses Alembic's upgrade command to apply any pending migrations.
 
     For existing databases without alembic_version table, it will first
-    stamp the database at the initial migration to avoid recreating tables.
+    stamp the database at the initial migration to avoid recreating tables,
+    then upgrade to head.
     """
     import asyncio
     import os
     import sqlite3
-    from concurrent.futures import ThreadPoolExecutor
 
     from alembic.config import Config
 
@@ -115,17 +121,16 @@ async def init_db() -> None:
                 conn.close()
 
                 if has_tables and not alembic_has_entries:
-                    # Existing database without alembic tracking (or empty alembic_version) - stamp it
-                    command.stamp(alembic_cfg, "head")
-                    return  # No upgrade needed, already at head
+                    # Existing database without alembic tracking (or empty alembic_version):
+                    # its schema matches the initial revision, so stamp it there and let
+                    # the upgrade below apply every later migration.
+                    command.stamp(alembic_cfg, _INITIAL_REVISION)
 
         # Run migrations
         command.upgrade(alembic_cfg, "head")
 
-    # Run migrations in a thread pool to avoid blocking the event loop
-    loop = asyncio.get_event_loop()
-    with ThreadPoolExecutor() as executor:
-        await loop.run_in_executor(executor, run_migrations)
+    # Run migrations in a thread to avoid blocking the event loop
+    await asyncio.to_thread(run_migrations)
 
 
 async def close_db() -> None:

--- a/backend/tests/unit/test_db_session.py
+++ b/backend/tests/unit/test_db_session.py
@@ -4,12 +4,18 @@ This module contains tests for the database session management functionality, in
 - Async session generator yielding AsyncSession instances
 - Context manager behavior for proper cleanup
 - Session independence across multiple calls
+- init_db migration behavior for fresh and legacy (untracked) databases
 """
+
+import asyncio
+import os
+import sqlite3
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.session import get_db
+from core.config import settings
+from db.session import _INITIAL_REVISION, get_db, init_db
 
 
 @pytest.mark.asyncio
@@ -61,3 +67,102 @@ async def test_multiple_get_db_calls_independent():
     # Sessions should be different objects
     assert len(sessions) == 2
     assert sessions[0] is not sessions[1]
+
+
+def _alembic_config():
+    """Build the same Alembic config init_db uses."""
+    from alembic.config import Config
+
+    import db.session as db_session
+
+    src_dir = os.path.dirname(os.path.dirname(os.path.abspath(db_session.__file__)))
+    cfg = Config(os.path.join(src_dir, "alembic.ini"))
+    cfg.set_main_option("script_location", os.path.join(src_dir, "alembic"))
+    return cfg
+
+
+def _head_revision():
+    from alembic.script import ScriptDirectory
+
+    return ScriptDirectory.from_config(_alembic_config()).get_current_head()
+
+
+def _db_revision(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute("SELECT version_num FROM alembic_version").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _column_names(db_path, table):
+    conn = sqlite3.connect(db_path)
+    try:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_init_db_fresh_database_migrates_to_head(tmp_path, monkeypatch):
+    """Test that init_db brings a brand-new database to the head revision."""
+    # GIVEN: A database URL pointing at a nonexistent SQLite file
+    db_path = tmp_path / "fresh.db"
+    monkeypatch.setattr(settings, "database_url", f"sqlite+aiosqlite:///{db_path}")
+
+    # WHEN: Initializing the database
+    await init_db()
+
+    # THEN: The database exists, is tracked at head, and has current-schema columns
+    assert db_path.exists()
+    assert _db_revision(db_path) == _head_revision()
+    assert "is_dlc" in _column_names(db_path, "giveaways")
+
+
+@pytest.mark.asyncio
+async def test_init_db_legacy_untracked_database_upgrades_to_head(tmp_path, monkeypatch):
+    """Test that an untracked initial-schema database is stamped then upgraded.
+
+    Regression test: init_db used to stamp untracked databases at *head* and
+    return, silently skipping every migration after the initial schema.
+    """
+    # GIVEN: A database at the initial schema revision with no alembic tracking
+    db_path = tmp_path / "legacy.db"
+    monkeypatch.setattr(settings, "database_url", f"sqlite+aiosqlite:///{db_path}")
+
+    from alembic import command
+
+    # env.py uses asyncio.run(), so alembic commands must run outside this loop
+    await asyncio.to_thread(command.upgrade, _alembic_config(), _INITIAL_REVISION)
+    conn = sqlite3.connect(db_path)
+    conn.execute("DROP TABLE alembic_version")
+    conn.commit()
+    conn.close()
+    assert "is_dlc" not in _column_names(db_path, "giveaways")
+
+    # WHEN: Initializing the database
+    await init_db()
+
+    # THEN: The database is upgraded to head with post-initial columns present
+    assert _db_revision(db_path) == _head_revision()
+    assert "is_dlc" in _column_names(db_path, "giveaways")
+
+
+@pytest.mark.asyncio
+async def test_init_db_tracked_database_applies_pending_migrations(tmp_path, monkeypatch):
+    """Test that a tracked database at an older revision is upgraded, not stamped."""
+    # GIVEN: A database tracked at the initial revision
+    db_path = tmp_path / "tracked.db"
+    monkeypatch.setattr(settings, "database_url", f"sqlite+aiosqlite:///{db_path}")
+
+    from alembic import command
+
+    await asyncio.to_thread(command.upgrade, _alembic_config(), _INITIAL_REVISION)
+    assert _db_revision(db_path) == _INITIAL_REVISION
+
+    # WHEN: Initializing the database
+    await init_db()
+
+    # THEN: Pending migrations are applied up to head
+    assert _db_revision(db_path) == _head_revision()
+    assert "is_dlc" in _column_names(db_path, "giveaways")


### PR DESCRIPTION
init_db stamped databases lacking alembic tracking at *head* and returned, which was correct when v2.0.0 shipped with a single migration but now silently skips every migration after the initial schema, leaving the app to crash on missing columns. Stamp at the initial revision instead and fall through to the normal upgrade. Also swap the manual executor for asyncio.to_thread.