### PR TITLE
Document the runtime data directory choice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,17 @@ npm install
 npm test  # Verify setup
 ```
 
+### Data directory
+
+The backend picks its data directory at runtime (`get_data_dir()` in
+`backend/src/core/config.py`): `/config` if it exists (the Docker volume,
+mounted from `./config` by the compose file), otherwise `./data` relative to
+the working directory — i.e. `backend/data/` when running uvicorn from
+`backend/`. Each holds a `steamselfgifter.db` and `app.log`, and both are
+gitignored, so a checkout that has seen both local and container runs will
+have two databases; check which one your process is using before inspecting
+data.
+
 ## Guidelines
 
 ### Code Style

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ npm run build
 
 The project uses Alembic for database migrations. Migrations run automatically on startup.
 
+The SQLite database lives in the runtime data directory: `/config` inside the
+container (mounted from `./config` by the compose file), or `./data` relative
+to the working directory when running the backend locally.
+
 ```bash
 # Create a new migration after model changes
 cd backend/src


### PR DESCRIPTION
The backend uses /config when it exists (Docker volume) and ./data otherwise, so local checkouts that have seen both local and container runs end up with two databases. Spell this out in the README and CONTRIBUTING so nobody inspects the wrong one.