### PR TITLE
Add mocked-HTTP integration tests for the SteamGifts and Steam clients

### DIFF
--- a/backend/src/utils/steam_client.py
+++ b/backend/src/utils/steam_client.py
@@ -137,6 +137,7 @@ class SteamClient:
         rate_limit_window: int = 60,
         max_retries: int = 3,
         timeout_seconds: int = 30,
+        transport: httpx.AsyncBaseTransport | None = None,
     ):
         """
         Initialize Steam API client.
@@ -147,6 +148,7 @@ class SteamClient:
             rate_limit_window: Rate limit window in seconds
             max_retries: Maximum retry attempts for failed requests
             timeout_seconds: Request timeout in seconds
+            transport: Optional httpx transport, used by tests to mock HTTP
 
         Example:
             >>> client = SteamClient(
@@ -164,6 +166,7 @@ class SteamClient:
             window_seconds=rate_limit_window
         )
 
+        self._transport = transport
         self._client: httpx.AsyncClient | None = None
 
     async def start(self) -> None:
@@ -183,7 +186,8 @@ class SteamClient:
             }
             self._client = httpx.AsyncClient(
                 timeout=self.timeout_seconds,
-                headers=headers
+                headers=headers,
+                transport=self._transport,
             )
 
     async def close(self) -> None:
@@ -411,7 +415,7 @@ class SteamClient:
 
         try:
             # Make a fresh request with browser-like headers to avoid 403
-            async with httpx.AsyncClient(timeout=30) as client:
+            async with httpx.AsyncClient(timeout=30, transport=self._transport) as client:
                 response = await client.get(
                     url,
                     params=params,

--- a/backend/src/utils/steamgifts_client.py
+++ b/backend/src/utils/steamgifts_client.py
@@ -96,6 +96,7 @@ class SteamGiftsClient:
         rate_limit_calls: int = 30,
         rate_limit_window: int = 60,
         max_retries: int = 3,
+        transport: httpx.AsyncBaseTransport | None = None,
     ):
         """
         Initialize SteamGifts client.
@@ -108,6 +109,7 @@ class SteamGiftsClient:
             rate_limit_calls: Max requests per rate-limit window
             rate_limit_window: Rate-limit window in seconds
             max_retries: Retry attempts for transient failures
+            transport: Optional httpx transport, used by tests to mock HTTP
 
         Example:
             >>> client = SteamGiftsClient(
@@ -126,6 +128,7 @@ class SteamGiftsClient:
             window_seconds=rate_limit_window,
         )
 
+        self._transport = transport
         self._client: httpx.AsyncClient | None = None
 
     async def start(self) -> None:
@@ -148,6 +151,7 @@ class SteamGiftsClient:
                 cookies=cookies,
                 headers=headers,
                 follow_redirects=True,
+                transport=self._transport,
             )
 
             # Extract XSRF token if not provided (only if we have a session)

--- a/backend/tests/integration_mocked/__init__.py
+++ b/backend/tests/integration_mocked/__init__.py
@@ -1,0 +1,8 @@
+"""Integration tests against mocked external HTTP services.
+
+Unlike tests/integration (which needs --run-integration and real
+credentials), these run unconditionally, in CI included: the real client
+code talks through httpx.MockTransport to canned SteamGifts/Steam
+responses, exercising cookies, headers, form encoding, retries, and
+parsing end to end without touching the network.
+"""

--- a/backend/tests/integration_mocked/conftest.py
+++ b/backend/tests/integration_mocked/conftest.py
@@ -1,0 +1,56 @@
+"""Shared fixtures for mocked-HTTP integration tests."""
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+class RoutedTransport(httpx.MockTransport):
+    """MockTransport with a per-path response table and request recording.
+
+    Register responses with add(); each registered path serves its responses
+    in order, repeating the last one once exhausted. Every request the client
+    makes is recorded in self.requests for assertions.
+    """
+
+    def __init__(self) -> None:
+        self._routes: dict[tuple[str, str], list[httpx.Response]] = {}
+        self.requests: list[httpx.Request] = []
+        super().__init__(self._handle)
+
+    def add(self, method: str, path: str, *responses: httpx.Response) -> None:
+        self._routes[(method.upper(), path)] = list(responses)
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        key = (request.method, request.url.path)
+        responses = self._routes.get(key)
+        if not responses:
+            raise AssertionError(f"Unexpected request: {request.method} {request.url}")
+        if len(responses) > 1:
+            return responses.pop(0)
+        return responses[0]
+
+
+@pytest.fixture
+def transport() -> RoutedTransport:
+    return RoutedTransport()
+
+
+@pytest.fixture(scope="session")
+def wishlist_html() -> str:
+    return (FIXTURES / "wishlist_page.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="session")
+def empty_search_html() -> str:
+    return (FIXTURES / "empty_search_page.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def no_sleep(mocker):
+    """Make retry backoffs instant; returns the mock for delay assertions."""
+    return mocker.patch("asyncio.sleep")

--- a/backend/tests/integration_mocked/test_steam_client_http.py
+++ b/backend/tests/integration_mocked/test_steam_client_http.py
@@ -1,0 +1,119 @@
+"""SteamClient against mocked Steam APIs over real httpx plumbing."""
+
+import httpx
+import pytest
+
+from utils.steam_client import (
+    SteamAPIError,
+    SteamAPIRateLimitError,
+    SteamClient,
+)
+
+pytestmark = pytest.mark.asyncio
+
+APP_DETAILS = {
+    "2525380": {
+        "success": True,
+        "data": {
+            "name": "Tomb Raider IV-VI Remastered",
+            "type": "game",
+            "steam_appid": 2525380,
+        },
+    }
+}
+
+
+class TestAppDetails:
+    async def test_success_parses_payload(self, transport):
+        transport.add("GET", "/api/appdetails", httpx.Response(200, json=APP_DETAILS))
+
+        async with SteamClient(transport=transport) as client:
+            details = await client.get_app_details(2525380)
+
+        assert details == APP_DETAILS["2525380"]["data"]
+        [request] = transport.requests
+        assert request.url.host == "store.steampowered.com"
+        assert request.url.params["appids"] == "2525380"
+
+    async def test_unsuccessful_lookup_returns_none(self, transport):
+        transport.add(
+            "GET", "/api/appdetails", httpx.Response(200, json={"999": {"success": False}})
+        )
+
+        async with SteamClient(transport=transport) as client:
+            assert await client.get_app_details(999) is None
+
+    async def test_404_returns_none(self, transport):
+        transport.add("GET", "/api/appdetails", httpx.Response(404))
+
+        async with SteamClient(transport=transport) as client:
+            assert await client.get_app_details(999) is None
+
+    async def test_429_raises_rate_limit_error(self, transport):
+        transport.add("GET", "/api/appdetails", httpx.Response(429))
+
+        async with SteamClient(transport=transport) as client:
+            with pytest.raises(SteamAPIRateLimitError):
+                await client.get_app_details(2525380)
+
+    async def test_5xx_retried_then_succeeds(self, transport, no_sleep):
+        transport.add(
+            "GET",
+            "/api/appdetails",
+            httpx.Response(500),
+            httpx.Response(503),
+            httpx.Response(200, json=APP_DETAILS),
+        )
+
+        async with SteamClient(transport=transport) as client:
+            details = await client.get_app_details(2525380)
+
+        assert details is not None
+        assert len(transport.requests) == 3
+
+    async def test_5xx_gives_up_after_max_retries(self, transport, no_sleep):
+        transport.add("GET", "/api/appdetails", httpx.Response(500))
+
+        async with SteamClient(transport=transport, max_retries=1) as client:
+            with pytest.raises(SteamAPIError):
+                await client.get_app_details(2525380)
+
+        assert len(transport.requests) == 2
+
+
+class TestAppReviews:
+    async def test_success_parses_summary(self, transport):
+        transport.add(
+            "GET",
+            "/appreviews/2525380",
+            httpx.Response(
+                200,
+                json={
+                    "success": 1,
+                    "query_summary": {
+                        "review_score": 9,
+                        "total_positive": 900,
+                        "total_negative": 100,
+                        "total_reviews": 1000,
+                    },
+                },
+            ),
+        )
+
+        async with SteamClient(transport=transport) as client:
+            reviews = await client.get_app_reviews(2525380)
+
+        assert reviews == {
+            "review_score": 9,
+            "total_positive": 900,
+            "total_negative": 100,
+            "total_reviews": 1000,
+        }
+        [request] = transport.requests
+        assert request.url.params["json"] == "1"
+
+    async def test_non_200_returns_none(self, transport):
+        transport.add("GET", "/appreviews/2525380", httpx.Response(403))
+
+        async with SteamClient(transport=transport) as client:
+            assert await client.get_app_reviews(2525380) is None

--- a/backend/tests/integration_mocked/test_steamgifts_client_http.py
+++ b/backend/tests/integration_mocked/test_steamgifts_client_http.py
@@ -1,0 +1,179 @@
+"""SteamGiftsClient against a mocked SteamGifts over real httpx plumbing.
+
+These exercise what the unit tests (which stub _get/_post) cannot: cookie
+and header wiring, query/form encoding, XSRF extraction on start, retry
+and backoff behavior, and client+parser integration on captured fixtures.
+"""
+
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+
+from utils.steamgifts_client import (
+    SteamGiftsClient,
+    SteamGiftsError,
+    SteamGiftsScrapeDriftError,
+    SteamGiftsSessionExpiredError,
+)
+
+pytestmark = pytest.mark.asyncio
+
+XSRF = "deadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def make_client(transport, **kwargs):
+    kwargs.setdefault("phpsessid", "sess-abc")
+    kwargs.setdefault("user_agent", "ua-test")
+    kwargs.setdefault("xsrf_token", XSRF)
+    return SteamGiftsClient(transport=transport, **kwargs)
+
+
+class TestSessionSetup:
+    async def test_start_extracts_xsrf_and_sends_cookie(self, transport, wishlist_html):
+        transport.add("GET", "/", httpx.Response(200, text=wishlist_html))
+
+        async with make_client(transport, xsrf_token=None) as client:
+            assert client.xsrf_token == XSRF
+
+        [request] = transport.requests
+        assert request.headers["Cookie"] == "PHPSESSID=sess-abc"
+        assert request.headers["User-Agent"] == "ua-test"
+
+    async def test_start_without_xsrf_on_page_raises_session_expired(self, transport):
+        transport.add("GET", "/", httpx.Response(200, text="<html><body></body></html>"))
+
+        client = make_client(transport, xsrf_token=None)
+        with pytest.raises(SteamGiftsSessionExpiredError):
+            await client.start()
+        await client.close()
+
+    async def test_get_user_points(self, transport, wishlist_html):
+        transport.add("GET", "/", httpx.Response(200, text=wishlist_html))
+
+        async with make_client(transport) as client:
+            assert await client.get_user_points() == 400
+
+
+class TestGiveawayListing:
+    async def test_wishlist_scan_parses_fixture(self, transport, wishlist_html):
+        transport.add("GET", "/giveaways/search", httpx.Response(200, text=wishlist_html))
+
+        async with make_client(transport) as client:
+            giveaways = await client.get_giveaways(page=2, giveaway_type="wishlist")
+
+        [ga] = giveaways
+        assert ga["code"] == "hVTVd"
+        assert ga["game_name"] == "Tomb Raider IV-VI Remastered"
+        assert ga["price"] == 30
+        assert ga["is_wishlist"] is True
+        assert ga["entries"] == 455
+
+        [request] = transport.requests
+        assert request.url.params["page"] == "2"
+        assert request.url.params["type"] == "wishlist"
+
+    async def test_dlc_scan_sends_dlc_param(self, transport, wishlist_html):
+        transport.add("GET", "/giveaways/search", httpx.Response(200, text=wishlist_html))
+
+        async with make_client(transport) as client:
+            giveaways = await client.get_giveaways(dlc_only=True)
+
+        assert giveaways[0]["is_dlc"] is True
+        [request] = transport.requests
+        assert request.url.params["dlc"] == "true"
+
+    async def test_empty_search_returns_empty_list(self, transport, empty_search_html):
+        transport.add("GET", "/giveaways/search", httpx.Response(200, text=empty_search_html))
+
+        async with make_client(transport) as client:
+            assert await client.get_giveaways(search_query="nonexistent") == []
+
+    async def test_unrecognizable_page_raises_drift_error(self, transport):
+        transport.add(
+            "GET", "/giveaways/search", httpx.Response(200, text="<html><body>hi</body></html>")
+        )
+
+        async with make_client(transport) as client:
+            with pytest.raises(SteamGiftsScrapeDriftError):
+                await client.get_giveaways()
+
+
+class TestEnterGiveaway:
+    async def test_success_posts_xsrf_form(self, transport):
+        transport.add("POST", "/ajax.php", httpx.Response(200, json={"type": "success"}))
+
+        async with make_client(transport) as client:
+            assert await client.enter_giveaway("hVTVd") is True
+
+        [request] = transport.requests
+        form = parse_qs(request.content.decode())
+        assert form == {
+            "xsrf_token": [XSRF],
+            "do": ["entry_insert"],
+            "code": ["hVTVd"],
+        }
+        assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+
+    async def test_rejection_returns_false(self, transport):
+        transport.add(
+            "POST",
+            "/ajax.php",
+            httpx.Response(200, json={"type": "error", "msg": "Not enough points"}),
+        )
+
+        async with make_client(transport) as client:
+            assert await client.enter_giveaway("hVTVd") is False
+
+
+class TestRetries:
+    async def test_get_retries_5xx_then_succeeds(self, transport, wishlist_html, no_sleep):
+        transport.add(
+            "GET",
+            "/",
+            httpx.Response(500),
+            httpx.Response(502),
+            httpx.Response(200, text=wishlist_html),
+        )
+
+        async with make_client(transport) as client:
+            assert await client.get_user_points() == 400
+
+        assert len(transport.requests) == 3
+
+    async def test_get_honors_retry_after_on_429(self, transport, wishlist_html, no_sleep):
+        transport.add(
+            "GET",
+            "/",
+            httpx.Response(429, headers={"Retry-After": "7"}),
+            httpx.Response(200, text=wishlist_html),
+        )
+
+        async with make_client(transport) as client:
+            assert await client.get_user_points() == 400
+
+        no_sleep.assert_awaited_once_with(7.0)
+
+    async def test_get_gives_up_after_max_retries(self, transport, no_sleep):
+        transport.add("GET", "/giveaways/search", httpx.Response(500))
+
+        async with make_client(transport, max_retries=1) as client:
+            with pytest.raises(SteamGiftsError):
+                await client.get_giveaways()
+
+        assert len(transport.requests) == 2
+
+    async def test_connect_errors_retried_then_wrapped(self, no_sleep):
+        attempts = 0
+
+        class FailingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request):
+                nonlocal attempts
+                attempts += 1
+                raise httpx.ConnectError("connection refused")
+
+        async with make_client(FailingTransport(), max_retries=1) as client:
+            with pytest.raises(SteamGiftsError):
+                await client.get_user_points()
+
+        assert attempts == 2

--- a/docs/TOFIX.md
+++ b/docs/TOFIX.md
@@ -29,7 +29,9 @@ render, driven by a tick interval).
 
 - [x] Re-enable `react-hooks/set-state-in-effect` after refactoring affected components
 - [x] Fix APScheduler event loop conflicts to enable scheduler e2e tests in CI (fixed by the automation-layer consolidation)
-- [ ] Add more integration test coverage with mocked external services
+- [x] Add more integration test coverage with mocked external services
+      (`tests/integration_mocked/` — real clients through `httpx.MockTransport`,
+      runs in CI; both clients take an optional `transport` for this)
 
 ### Dependency Notes
 


### PR DESCRIPTION
New tests/integration_mocked/ suite runs the real clients through httpx.MockTransport — unlike the unit tests (which stub _get/_post) it covers cookie/header wiring, query and form encoding, XSRF extraction on start, 5xx/429/connect-error retry behavior including Retry-After, drift detection, and client+parser integration on the captured page fixtures. Runs unconditionally in CI; the credential-gated tests/integration suite is unchanged. Both clients gain an optional transport parameter as the injection seam. Closes the TOFIX item.