### PR TITLE
Fix the two long-standing mypy errors

### DIFF
--- a/backend/src/api/schemas/giveaway.py
+++ b/backend/src/api/schemas/giveaway.py
@@ -124,7 +124,9 @@ class GiveawayResponse(GiveawayBase):
         examples=[123],
     )
 
-    @computed_field(description="Win chance in percent (copies/entries*100) as of the last scan")
+    @computed_field(  # type: ignore[prop-decorator]  # pydantic-documented mypy limitation
+        description="Win chance in percent (copies/entries*100) as of the last scan"
+    )
     @property
     def win_chance(self) -> float:
         """Chance to win in percent; 100 when nobody has entered yet.

--- a/backend/src/workers/processor.py
+++ b/backend/src/workers/processor.py
@@ -122,9 +122,9 @@ async def _process_entries(
             event_type="entry",
             message=f"Accumulating points: {points}P is below the {start_at}P start threshold",
         )
-        stats = _skipped_stats("points_below_start_threshold")
-        stats["points_available"] = points
-        return stats
+        skip_stats = _skipped_stats("points_below_start_threshold")
+        skip_stats["points_available"] = points
+        return skip_stats
 
     # Evaluate the candidate pool: this both selects the eligible giveaways and
     # records a per-giveaway eligibility reason for the ones that didn't qualify.


### PR DESCRIPTION
Rename the early-return skip stats in _process_entries so the annotated main stats dict is no longer a redefinition, and silence prop-decorator on the win_chance computed_field — pydantic's documented workaround for a mypy limitation with @computed_field over @property.