### PR TITLE
Revamp the safety mechanism: scoped detection, three-way verdict, sweep

### DIFF
--- a/backend/src/alembic/versions/f1b8c5d3a9e2_add_giveaway_safety_checked_at.py
+++ b/backend/src/alembic/versions/f1b8c5d3a9e2_add_giveaway_safety_checked_at.py
@@ -1,0 +1,35 @@
+"""Add giveaways.safety_checked_at for safety verdict freshness
+
+Revision ID: f1b8c5d3a9e2
+Revises: e9a3b6c4d2f7
+Create Date: 2026-07-21
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f1b8c5d3a9e2"
+down_revision: str | Sequence[str] | None = "e9a3b6c4d2f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("giveaways") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "safety_checked_at",
+                sa.DateTime(),
+                nullable=True,
+                comment="When the safety verdict was last computed (UTC); NULL = never checked",
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("giveaways") as batch_op:
+        batch_op.drop_column("safety_checked_at")

--- a/backend/src/models/giveaway.py
+++ b/backend/src/models/giveaway.py
@@ -168,6 +168,11 @@ class Giveaway(Base, TimestampMixin):
         nullable=True,
         comment="Scam detection confidence (0-100)",
     )
+    safety_checked_at: Mapped[datetime | None] = mapped_column(
+        DateTime,
+        nullable=True,
+        comment="When the safety verdict was last computed (UTC); NULL = never checked",
+    )
 
     # ==================== Eligibility Diagnostics ====================
     eligibility_reason: Mapped[str | None] = mapped_column(

--- a/backend/src/repositories/giveaway.py
+++ b/backend/src/repositories/giveaway.py
@@ -246,12 +246,14 @@ class GiveawayRepository(BaseRepository[Giveaway]):
         """
         now = utcnow()
 
-        # Base filters: active, not hidden, not entered
+        # Base filters: active, not hidden, not entered, not flagged by the
+        # safety check (NULL = unchecked passes; mirrors evaluate_eligibility)
         base_conditions = [
             self.model.end_time.isnot(None),
             self.model.end_time > now,
             self.model.is_hidden == False,  # noqa: E712
             self.model.is_entered == False,  # noqa: E712
+            self.model.is_safe.isnot(False),
         ]
 
         # Wishlist giveaways bypass the price and game-quality filters;

--- a/backend/src/services/eligibility.py
+++ b/backend/src/services/eligibility.py
@@ -32,6 +32,7 @@ ELIGIBLE = "eligible"
 EXPIRED = "expired"
 HIDDEN = "hidden"
 ENTERED = "entered"
+UNSAFE = "unsafe"
 PRICE_BELOW_MIN = "price_below_min"
 PRICE_ABOVE_MAX = "price_above_max"
 NO_GAME_DATA = "no_game_data"
@@ -45,6 +46,7 @@ REASON_LABELS = {
     EXPIRED: "Giveaway has ended",
     HIDDEN: "Hidden",
     ENTERED: "Already entered",
+    UNSAFE: "Flagged unsafe or borderline by the safety check",
     PRICE_BELOW_MIN: "Price below minimum",
     PRICE_ABOVE_MAX: "Price above maximum",
     NO_GAME_DATA: "No Steam game data cached",
@@ -105,6 +107,12 @@ def evaluate_eligibility(giveaway: Any, game: Any, criteria: EligibilityCriteria
 
     if giveaway.is_entered:
         return ENTERED
+
+    # Safety verdicts: is_safe False covers both outright traps (also hidden)
+    # and borderline scores — automation never touches either. NULL (never
+    # checked) passes; the inline entry check still guards those.
+    if giveaway.is_safe is False:
+        return UNSAFE
 
     # Wishlist games are wanted by definition: they bypass the price and
     # game-quality filters (matches the `is_wishlist OR (...)` in the SQL),

--- a/backend/src/services/giveaway_entry.py
+++ b/backend/src/services/giveaway_entry.py
@@ -1,16 +1,28 @@
 """Entry-side methods of GiveawayService: entering giveaways (with optional
 inline safety check), safety scoring, hiding on SteamGifts, comments, points."""
 
+import asyncio
+import random
+from datetime import timedelta
+from typing import Any
+
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.exceptions import SteamGiftsError
+from core.time import utcnow
 from models.entry import Entry
+from models.giveaway import Giveaway
 from repositories.entry import EntryRepository
 from repositories.giveaway import GiveawayRepository
+from utils import steamgifts_parser as parser
 from utils.steamgifts_client import SteamGiftsClient
 
 logger = structlog.get_logger()
+
+# Stored safety verdicts younger than this are trusted at entry time without
+# refetching the giveaway page (the background sweep keeps them fresh).
+SAFETY_RECHECK_HOURS = 24
 
 
 class GiveawayEntryMixin:
@@ -106,8 +118,11 @@ class GiveawayEntryMixin:
         """
         Enter a giveaway with safety check.
 
-        Checks if the giveaway is safe before entering. If unsafe,
-        the giveaway is hidden instead of entered.
+        Uses the stored safety verdict when fresh (see SAFETY_RECHECK_HOURS),
+        otherwise checks the giveaway page. Outcomes: "safe" enters normally;
+        "borderline" skips without hiding (left for manual review); "unsafe"
+        hides the giveaway on SteamGifts. A failing safety check skips the
+        giveaway this cycle (fail closed).
 
         Args:
             giveaway_code: Giveaway code to enter
@@ -121,36 +136,94 @@ class GiveawayEntryMixin:
             >>> if entry:
             ...     print("Entered safely!")
         """
-        # First check safety
+        # Fail closed: a safety check that errors skips the giveaway for this
+        # cycle (it stays eligible and is retried next cycle) instead of
+        # entering unchecked.
         try:
-            safety = await self.check_giveaway_safety(giveaway_code)
-
-            if not safety["is_safe"]:
-                logger.warning("giveaway_unsafe", code=giveaway_code, details=safety["details"])
-
-                # Try to hide it on SteamGifts
-                await self.hide_on_steamgifts(giveaway_code)
-
-                # Record failed entry with reason
-                giveaway = await self.giveaway_repo.get_by_code(giveaway_code)
-                if giveaway:
-                    await self.entry_repo.create(
-                        giveaway_id=giveaway.id,
-                        points_spent=0,
-                        entry_type=entry_type,
-                        status="failed",
-                        error_message=f"Unsafe giveaway: {', '.join(safety['details'])}",
-                    )
-                    await self.session.commit()
-
-                return None
-
+            safety = await self._current_safety(giveaway_code)
         except Exception as e:
-            logger.error("safety_check_failed", code=giveaway_code, error=str(e))
-            # Continue without safety check if it fails
+            logger.warning("safety_check_failed_skipping", code=giveaway_code, error=str(e))
+            return None
+
+        verdict = safety.get("verdict", "safe" if safety["is_safe"] else "unsafe")
+
+        if verdict == "unsafe":
+            logger.warning("giveaway_unsafe", code=giveaway_code, details=safety["details"])
+            await self.hide_on_steamgifts(giveaway_code)
+            await self._record_safety_rejection(
+                giveaway_code,
+                entry_type,
+                f"Unsafe giveaway (score {safety['safety_score']}): "
+                f"{', '.join(safety['details'])}",
+            )
+            return None
+
+        if verdict == "borderline":
+            # Suspicious but not certain: skip without hiding so the giveaway
+            # stays visible for manual review. is_safe=False keeps it out of
+            # future eligible pools.
+            logger.warning(
+                "giveaway_borderline_skipped",
+                code=giveaway_code,
+                score=safety["safety_score"],
+                details=safety["details"],
+            )
+            await self._record_safety_rejection(
+                giveaway_code,
+                entry_type,
+                f"Borderline safety score {safety['safety_score']}, "
+                "skipped for manual review",
+            )
+            return None
 
         # Proceed with normal entry
         return await self.enter_giveaway(giveaway_code, entry_type)
+
+    async def _current_safety(self, giveaway_code: str) -> dict[str, Any]:
+        """Return a safety verdict, reusing a fresh stored one when possible."""
+        giveaway = await self.giveaway_repo.get_by_code(giveaway_code)
+        if (
+            giveaway is not None
+            and giveaway.is_safe is not None
+            and giveaway.safety_checked_at is not None
+            and utcnow() - giveaway.safety_checked_at < timedelta(hours=SAFETY_RECHECK_HOURS)
+        ):
+            return self._verdict_from_stored(giveaway)
+        return await self.check_giveaway_safety(giveaway_code)
+
+    @staticmethod
+    def _verdict_from_stored(giveaway: Giveaway) -> dict[str, Any]:
+        """Rebuild a verdict dict from the persisted safety fields."""
+        score = giveaway.safety_score or 0
+        if giveaway.is_safe:
+            verdict = "safe"
+        elif score >= parser.UNSAFE_THRESHOLD:
+            verdict = "borderline"
+        else:
+            verdict = "unsafe"
+        return {
+            "verdict": verdict,
+            "is_safe": bool(giveaway.is_safe),
+            "safety_score": score,
+            "details": [],
+            "warning_comments": 0,
+            "cached": True,
+        }
+
+    async def _record_safety_rejection(
+        self, giveaway_code: str, entry_type: str, reason: str
+    ) -> None:
+        """Record a failed entry documenting why safety blocked this giveaway."""
+        giveaway = await self.giveaway_repo.get_by_code(giveaway_code)
+        if giveaway:
+            await self.entry_repo.create(
+                giveaway_id=giveaway.id,
+                points_spent=0,
+                entry_type=entry_type,
+                status="failed",
+                error_message=reason,
+            )
+            await self.session.commit()
 
     async def check_giveaway_safety(self, giveaway_code: str) -> dict:
         """
@@ -181,9 +254,50 @@ class GiveawayEntryMixin:
         if giveaway:
             giveaway.is_safe = safety_result["is_safe"]
             giveaway.safety_score = safety_result["safety_score"]
+            giveaway.safety_checked_at = utcnow()
             await self.session.commit()
 
         return safety_result
+
+    async def sweep_unchecked_safety(
+        self, limit: int = 10, delay_min: float = 1.0, delay_max: float = 3.0
+    ) -> dict[str, int]:
+        """Safety-check a batch of unchecked active giveaways (background sweep).
+
+        Fetches up to ``limit`` giveaways that have never been checked
+        (``is_safe`` NULL), oldest-expiring first, scores each page, and hides
+        outright traps — so most giveaways carry a stored verdict before the
+        entry loop ever considers them. A short random delay between page
+        fetches keeps the traffic pattern polite.
+
+        Returns:
+            Counts: ``{"checked", "safe", "borderline", "unsafe", "errors"}``.
+        """
+        unchecked = await self.giveaway_repo.get_unchecked_eligible(limit=limit)
+        counts = {"checked": 0, "safe": 0, "borderline": 0, "unsafe": 0, "errors": 0}
+
+        for index, giveaway in enumerate(unchecked):
+            if index:
+                await asyncio.sleep(random.uniform(delay_min, delay_max))
+
+            try:
+                result = await self.check_giveaway_safety(giveaway.code)
+            except Exception as e:
+                counts["errors"] += 1
+                logger.warning("safety_sweep_check_failed", code=giveaway.code, error=str(e))
+                continue
+
+            counts["checked"] += 1
+            verdict = result.get("verdict", "safe" if result["is_safe"] else "unsafe")
+            counts[verdict] += 1
+
+            if verdict == "unsafe":
+                logger.warning(
+                    "safety_sweep_unsafe", code=giveaway.code, details=result["details"]
+                )
+                await self.hide_on_steamgifts(giveaway.code)
+
+        return counts
 
     async def hide_on_steamgifts(self, giveaway_code: str) -> bool:
         """

--- a/backend/src/utils/steamgifts_client.py
+++ b/backend/src/utils/steamgifts_client.py
@@ -17,10 +17,6 @@ from core.exceptions import (
 from utils import steamgifts_parser as parser
 from utils.steam_client import RateLimiter
 
-# Re-exported for backwards compatibility; the parsing logic (and these
-# word lists) live in utils.steamgifts_parser.
-from utils.steamgifts_parser import FORBIDDEN_WORDS, GOOD_WORDS  # noqa: F401
-
 logger = structlog.get_logger()
 
 

--- a/backend/src/utils/steamgifts_parser.py
+++ b/backend/src/utils/steamgifts_parser.py
@@ -22,11 +22,44 @@ from core.time import from_timestamp
 
 logger = structlog.get_logger()
 
-# Safety detection word lists (from legacy code)
-# Words that indicate potential traps/scams
-FORBIDDEN_WORDS = (" ban", " fake", " bot", " not enter", " don't enter", " do not enter")
-# Words that look similar but are innocent (to avoid false positives)
-GOOD_WORDS = (" bank", " banan", " both", " band", " banner", " bang")
+# === Trap/scam giveaway detection ===
+#
+# Matching is scoped to the giveaway *description* and (at lower weight) the
+# comment thread — never the whole page — so navigation, sidebar and other
+# giveaways' text can't trigger false positives. Patterns are word-boundary
+# regexes with a weight; higher-weight phrases are near-certain trap language.
+TRAP_PATTERNS: tuple[tuple[re.Pattern[str], int], ...] = (
+    (re.compile(r"\bdo\s+not\s+enter\b"), 3),
+    (re.compile(r"\bdon[o'’]?t\s+enter\b"), 3),
+    (re.compile(r"\bbot\s+trap\b"), 3),
+    (re.compile(r"\bfor\s+bots?\b"), 3),
+    (re.compile(r"\btest(?:ing)?\s+(?:for\s+)?bots?\b"), 3),
+    (re.compile(r"\bfake\s+giveaway\b"), 3),
+    (re.compile(r"\btroll\s+giveaway\b"), 3),
+    (re.compile(r"\b(?:will\s+(?:get|be)|you(?:'ll|\s+will)\s+(?:get|be))\s+banned\b"), 3),
+    (re.compile(r"\breport(?:ed)?\s+to\s+(?:support|steamgifts|cg)\b"), 3),
+    (re.compile(r"\bbanned\b"), 2),
+    (re.compile(r"\bban\b"), 2),
+    (re.compile(r"\btrap\b"), 2),
+    (re.compile(r"\bsuspend(?:ed|s)?\b"), 2),
+    (re.compile(r"\bstay\s+away\b"), 2),
+    (re.compile(r"\bnot\s+enter\b"), 2),
+    (re.compile(r"\bfake\b"), 1),
+    (re.compile(r"\bblacklist(?:ed)?\b"), 1),
+    (re.compile(r"\bsuspicious\b"), 1),
+)
+
+# Score bands: >= SAFE_THRESHOLD is safe to auto-enter; scores in
+# [UNSAFE_THRESHOLD, SAFE_THRESHOLD) are "borderline" — skipped by automation
+# but left visible for manual review; below UNSAFE_THRESHOLD is an outright
+# trap (hidden). Description hits cost 20 points per weight; each warning
+# comment costs 5 per weight (capped) so a single commenter can't sink a
+# legitimate giveaway but a chorus of warnings drops it to borderline.
+SAFE_THRESHOLD = 85
+UNSAFE_THRESHOLD = 50
+_DESCRIPTION_PENALTY = 20
+_COMMENT_PENALTY = 5
+_COMMENT_WEIGHT_CAP = 8
 
 
 def has_no_results_marker(html: str) -> bool:
@@ -441,58 +474,96 @@ def parse_giveaway_game_id(html: str) -> int | None:
     return None
 
 
-def check_page_safety(html_content: str) -> dict[str, Any]:
-    """
-    Check if a giveaway page contains suspicious content.
+def extract_giveaway_texts(html: str) -> dict[str, Any]:
+    """Extract the description and comment texts from a giveaway page.
 
-    Analyzes the page text for forbidden words that might indicate
-    a trap giveaway (e.g., "don't enter", "ban", "fake").
+    Returns ``{"description": str, "comments": list[str]}``. A giveaway
+    without a description yields an empty string; collapsed-comment
+    placeholders (``comment__collapse-state``) are excluded.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    description = ""
+    desc_el = soup.select_one(".page__description .markdown")
+    if desc_el:
+        description = desc_el.get_text(" ", strip=True)
+
+    comments = [
+        el.get_text(" ", strip=True)
+        for el in soup.select(".comment__display-state .comment__description")
+    ]
+
+    return {"description": description, "comments": comments}
+
+
+def _match_weight(text: str) -> tuple[int, list[str]]:
+    """Total trap-pattern weight in ``text`` plus the matched pattern strings."""
+    lowered = text.lower()
+    weight = 0
+    matched = []
+    for pattern, pattern_weight in TRAP_PATTERNS:
+        hits = len(pattern.findall(lowered))
+        if hits:
+            weight += pattern_weight * hits
+            matched.append(pattern.pattern)
+    return weight, matched
+
+
+def score_giveaway_safety(description: str, comments: list[str]) -> dict[str, Any]:
+    """Score trap likelihood from a giveaway's description and comments.
 
     Returns:
         Dictionary with safety check results:
-            - is_safe: True if page appears safe
-            - safety_score: Score from 0-100 (higher = safer)
-            - bad_count: Number of bad words found
-            - good_count: Number of good words found (false positives)
-            - details: List of found bad words
+            - verdict: "safe" | "borderline" | "unsafe"
+            - is_safe: True only when verdict is "safe"
+            - safety_score: 0-100 (higher = safer)
+            - details: matched trap patterns (description first)
+            - warning_comments: number of comments containing trap language
     """
-    text_lower = html_content.lower()
+    desc_weight, desc_matched = _match_weight(description)
 
-    bad_count = 0
-    good_count = 0
-    found_bad_words = []
+    warning_comments = 0
+    comment_weight = 0
+    comment_matched: list[str] = []
+    for comment in comments:
+        weight, matched = _match_weight(comment)
+        if weight:
+            warning_comments += 1
+            # One comment counts once, at its strongest signal.
+            comment_weight += max(
+                pattern_weight
+                for pattern, pattern_weight in TRAP_PATTERNS
+                if pattern.pattern in matched
+            )
+            comment_matched.extend(m for m in matched if m not in comment_matched)
+    comment_weight = min(comment_weight, _COMMENT_WEIGHT_CAP)
 
-    # Count forbidden words
-    for bad_word in FORBIDDEN_WORDS:
-        count = text_lower.count(bad_word.lower())
-        if count > 0:
-            bad_count += count
-            found_bad_words.append(bad_word.strip())
+    score = max(
+        0, 100 - _DESCRIPTION_PENALTY * desc_weight - _COMMENT_PENALTY * comment_weight
+    )
 
-    # Count good words (false positive indicators)
-    if bad_count > 0:
-        for good_word in GOOD_WORDS:
-            good_count += text_lower.count(good_word.lower())
-
-    # Calculate safety score
-    # Net bad = bad words minus false positives
-    net_bad = max(0, bad_count - good_count)
-
-    if net_bad == 0:
-        safety_score = 100
-        is_safe = True
-    elif net_bad <= 2:
-        safety_score = 50
-        is_safe = True  # Borderline, but allow
+    if score >= SAFE_THRESHOLD:
+        verdict = "safe"
+    elif score >= UNSAFE_THRESHOLD:
+        verdict = "borderline"
     else:
-        safety_score = max(0, 100 - (net_bad * 20))
-        is_safe = False
+        verdict = "unsafe"
 
     return {
-        "is_safe": is_safe,
-        "safety_score": safety_score,
-        "bad_count": bad_count,
-        "good_count": good_count,
-        "net_bad": net_bad,
-        "details": found_bad_words,
+        "verdict": verdict,
+        "is_safe": verdict == "safe",
+        "safety_score": score,
+        "details": desc_matched + [m for m in comment_matched if m not in desc_matched],
+        "warning_comments": warning_comments,
     }
+
+
+def check_page_safety(html_content: str) -> dict[str, Any]:
+    """Check a giveaway page for trap/scam language.
+
+    Extracts the description and comment thread from the page and scores
+    them with :func:`score_giveaway_safety` — surrounding page chrome
+    (navigation, sidebar, other giveaways) is never matched.
+    """
+    texts = extract_giveaway_texts(html_content)
+    return score_giveaway_safety(texts["description"], texts["comments"])

--- a/backend/src/workers/automation.py
+++ b/backend/src/workers/automation.py
@@ -6,7 +6,8 @@ Single unified job that performs all automated tasks in sequence:
 3. Scan DLC giveaways
 4. Sync wins
 5. Sync entered giveaways
-6. Process eligible giveaways (enter them)
+6. Safety-sweep unchecked giveaways
+7. Process eligible giveaways (enter them)
 
 This is the engine driven both by the scheduler (interval job) and by the
 manual ``/run`` trigger. It shares its bootstrap with the other workers via
@@ -164,6 +165,24 @@ async def automation_cycle() -> dict[str, Any]:
             except Exception as e:
                 logger.error("sync_entered_failed", error=str(e))
                 results["entered_sync"]["error"] = str(e)
+
+            # === STEP 3.75: Safety sweep ===
+            # Score unchecked giveaways before entry selection so verdicts are
+            # already stored when the entry loop runs (and traps are hidden).
+            logger.info("automation_step", step="safety_sweep")
+            results["safety_sweep"] = {"checked": 0, "skipped": False}
+
+            if not settings.safety_check_enabled:
+                results["safety_sweep"]["skipped"] = True
+                results["safety_sweep"]["reason"] = "safety_check_disabled"
+            else:
+                try:
+                    sweep_counts = await giveaway_service.sweep_unchecked_safety(limit=10)
+                    results["safety_sweep"] = {**sweep_counts, "skipped": False}
+                    logger.info("safety_sweep_completed", **sweep_counts)
+                except Exception as e:
+                    logger.error("safety_sweep_failed", error=str(e))
+                    results["safety_sweep"]["error"] = str(e)
 
             # === STEP 4: Process entries ===
             logger.info("automation_step", step="process_entries")

--- a/backend/tests/fixtures/giveaway_page.html
+++ b/backend/tests/fixtures/giveaway_page.html
@@ -1,0 +1,620 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+						<link rel="shortcut icon" href="https://cdn.steamgifts.com/img/favicon.ico">
+		<title>Children of Silentown</title>
+		<!-- Google Fonts -->
+		<link rel="preconnect" href="https://fonts.gstatic.com">
+		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600;700&family=Roboto+Mono&display=swap" rel="stylesheet">
+		<!-- Include FontAwesome -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+		<!-- Include CSS -->
+		<link rel="stylesheet" href="https://cdn.steamgifts.com/css/bundle-v10.css">
+		<!-- Include Scripts -->
+		
+		
+		<meta name="viewport" content="width=1200">
+		
+							<style>
+				.adsbygoogle[data-ad-status="unfilled"], .adsbygoogle:empty {
+					height: 0 !important;
+				}
+			</style>
+			
+						
+	</head>
+	<body>
+					<div class="lightbox hide">
+				<div class="lightbox-header">
+					<div class="lightbox-header-description">
+						<div class="lightbox-header-description-name"></div>
+						<div class="lightbox-header-description-count"></div>
+					</div>
+					<div class="lightbox-header-icons">
+						<i data-category="images" class="lightbox-header-icon fa fa-camera"></i>
+						<i data-category="videos" class="lightbox-header-icon fa fa-video-camera"></i>
+						<i class="lightbox-header-icon lightbox-header-icon--close fa fa-times"></i>
+					</div>
+				</div>
+				<div class="lightbox-status lightbox-status--loading">
+					<div>
+						<div class="lightbox-status-icon"><i class="fa fa-cog fa-spin"></i></div>
+						<div class="lightbox-status-text">Please wait</div>
+					</div>
+				</div>
+				<div class="lightbox-status lightbox-status--empty">
+					<div>
+						<div class="lightbox-status-icon"><i class="fa fa-picture-o"></i></div>
+						<div class="lightbox-status-text">No results</div>
+					</div>
+				</div>
+				<div class="lightbox-content">
+					<div class="lightbox-content-nav">
+						<div class="lightbox-content-nav-btn lightbox-content-nav-btn--prev">
+							<div class="lightbox-content-nav-btn-icon"><i class="fa fa-angle-left"></i></div>
+						</div>
+						<div class="lightbox-content-nav-btn lightbox-content-nav-btn--next">
+							<div class="lightbox-content-nav-btn-icon"><i class="fa fa-angle-right"></i></div>
+						</div>
+					</div>
+					<div class="lightbox-content-image"></div>
+				</div>
+				<div class="lightbox-footer-outer">
+					<div class="lightbox-footer-inner">
+						<div class="lightbox-thumbnails"></div>
+					</div>
+				</div>
+			</div>
+					<header>
+			<nav>
+									<div class="nav__left-container">
+						<div class="nav__button-container">
+							<div class="nav__relative-dropdown is-hidden">
+								<div class="nav__absolute-dropdown">
+									<a class="nav__row" href="/giveaways/wishlist">
+										<i class="icon-blue fa fa-fw fa-users"></i>
+										<div class="nav__row__summary">
+											<p class="nav__row__summary__name">Community Wishlist</p>
+											<p class="nav__row__summary__description">Search for new games to share.</p>
+										</div>
+									</a>							
+								</div>
+							</div>	
+							<a class="nav__button nav__button--is-dropdown" href="/">Giveaways</a>
+							<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+						</div>
+												<div class="nav__button-container">
+							<a class="nav__button" href="/discussions/deals">Deals</a>
+						</div>
+						<div class="nav__button-container">
+							<a class="nav__button" href="/discussions">Discussions</a>
+						</div>
+						<div class="nav__button-container">
+							<div class="nav__relative-dropdown is-hidden">
+								<div class="nav__absolute-dropdown">
+									<a class="nav__row" href="/about/guidelines">
+										<i class="icon-blue fa fa-fw fa-file-text-o"></i>
+										<div class="nav__row__summary">
+											<p class="nav__row__summary__name">Guidelines</p>
+											<p class="nav__row__summary__description">Community rules and guidelines.</p>
+										</div>
+									</a>
+									<a class="nav__row" href="/about/faq">
+										<i class="icon-grey fa fa-fw fa-question-circle"></i>
+										<div class="nav__row__summary">
+											<p class="nav__row__summary__name">FAQ</p>
+											<p class="nav__row__summary__description">Frequently asked questions.</p>
+										</div>
+									</a>
+									<a class="nav__row" href="/about/comment-formatting">
+										<i class="icon-red fa fa-fw fa-code"></i>
+										<div class="nav__row__summary">
+											<p class="nav__row__summary__name">Comment Formatting</p>
+											<p class="nav__row__summary__description">Syntax for writing comments.</p>
+										</div>
+									</a>
+								</div>
+							</div>	
+							<a class="nav__button nav__button--is-dropdown" href="/about/faq">Help</a>
+							<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+						</div>
+					</div>
+					<div class="nav__right-container">
+													<div class="nav__button-container">
+							<a href="https://steamcommunity.com/openid/login?openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&amp;openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&amp;openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&amp;openid.mode=checkid_setup&amp;openid.return_to=https%3A%2F%2Fwww.steamgifts.com%2Fgiveaway%2F0UzGN%2Fchildren-of-silentown" rel="nofollow" class="nav__sits"><i class="fa fa-steam"></i> Sign in through STEAM</a>
+							</div>
+												</div>
+								</nav>
+		</header>
+		
+			<div class="featured__container">
+				<div class="featured__outer-wrap featured__outer-wrap--giveaway" style="background-color:rgb(0,69,89)">
+					<div class="featured__inner-wrap">
+						<a href="https://store.steampowered.com/app/1108000?utm_source=SteamGifts" rel="nofollow noopener" target="_blank" class="global__image-outer-wrap global__image-outer-wrap--game-large">
+							<img src="https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/1108000/header_292x136.jpg?t=1777538596" />
+						</a>
+						<div class="featured__summary">
+							<div class="featured__heading">
+								<div class="featured__heading__medium">Children of Silentown</div>
+								
+								<div class="featured__heading__small">(20P)</div><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-steam&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Steam Store&quot;}]}]}" rel="nofollow noopener" target="_blank" href="https://store.steampowered.com/app/1108000?utm_source=SteamGifts"><i class="fa fa-fw fa-steam"></i></a><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-camera&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Screenshots / Videos&quot;}]}]}" data-lightbox-id="4229846838"><i class="fa fa-fw fa-camera"></i></a><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-search&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;More Giveaways&quot;}]}]}" title="Free Steam Giveaways and Keys for Children of Silentown" href="/game/bZLaS/children-of-silentown"><i class="fa fa-fw fa-search"></i></a>
+							</div>
+							<div class="featured__columns">				
+								<div class="featured__column"><i style="color:rgb(102,181,204);" class="fa fa-clock-o"></i> <span data-timestamp="1784588400">23 minutes</span> remaining</div>
+								<div class="featured__column featured__column--width-fill text-right"><span data-timestamp="1784484525">1 day</span> ago by <a style="color:rgb(102,181,204);" href="/user/TestUser14">TestUser14</a></div><a href="/user/TestUser14" class="featured_giveaway_image_avatar" style="background-image:url(avatar.jpg);"></a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>		<div class="page__outer-wrap">
+			<div class="page__inner-wrap">
+				<div class="widget-container">
+					<div class="sidebar" style="width: 300px; min-width: 300px;">
+						<a href="https://steamcommunity.com/openid/login?openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&amp;openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&amp;openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&amp;openid.mode=checkid_setup&amp;openid.return_to=https%3A%2F%2Fwww.steamgifts.com%2Fgiveaway%2F0UzGN%2Fchildren-of-silentown" rel="nofollow" class="sidebar__error"><i class="fa fa-steam"></i> Sign in to Enter Giveaway</a>
+				<div class="sidebar__search-container">
+					<input class="sidebar__search-input" name="search-query" type="text" placeholder="Search..." value="" />
+					<i class="fa fa-search"></i>
+				</div>
+				<div class="sidebar__heading">Giveaway</div><ul class="sidebar__navigation">
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item is-selected"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaway/0UzGN/children-of-silentown"><i class="fa fa-caret-right"></i> 
+									<div class="sidebar__navigation__item__name">Comments</div>
+									<div class="sidebar__navigation__item__underline"></div><div class="sidebar__navigation__item__count">6</div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaway/0UzGN/children-of-silentown/entries">
+									<div class="sidebar__navigation__item__name">Entries</div>
+									<div class="sidebar__navigation__item__underline"></div><div class="sidebar__navigation__item__count live__entry-count">2,626</div>
+								</a>
+							</li></ul><div class="sidebar__heading">Tools</div><ul class="sidebar__navigation">
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaway/0UzGN/children-of-silentown/stats">
+									<div class="sidebar__navigation__item__name">Stats</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li></ul><div class="avvsw"><a style=" margin: 25px 0 0 0;" class="fanatical_container hide vertical" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.fanatical.com%2Fen%2Fbundle%2Finto-games-charity-bundle-2026"><img class="fanatical_img" src="https://fanatical.imgix.net/product/original/0fbf267b-6be6-45b5-b1b9-3fa7db485450.jpeg?auto=format&amp;w=&amp;fit=crop&amp;h=200" /><div class="fanatical_description"><div><span class="fanatical_new">New</span> <span class="fanatical_name">Into Games Charity Bundle 2026</span></div><div class="fanatical_date"><i class="fa fa-clock-o"></i><div>Started <span data-timestamp="1784541600">12 hours</span> ago</div></div></div><div class="fanatical_summary"><div class="fanatical_icons"><div class="fanatical_icon" style="background-image: url(avatar.jpg);"></div></div><div class="fanatical_pricing">$14.99</div></div></a>
+						<div style="padding-top: 35px;">
+							<!-- sg_giveaway_top_responsive -->
+							<ins class="adsbygoogle"
+								 style="display:block"
+								 data-ad-client="ca-pub-7519145598166360"
+								 data-ad-slot="9451237317"
+								 data-ad-format="auto"
+								 data-full-width-responsive="true"></ins>
+							
+						</div>
+					</div>						
+					</div>
+					<div>
+												<div class="page__heading">
+							<div class="page__heading__breadcrumbs"><a href="/giveaway/0UzGN/children-of-silentown">6 Comments</a></div>						</div>
+						<div class="comments">
+					<div data-comment-id="64483444" class="comment">
+						<div class="ajax comment__parent">
+							<a href="/user/TestUser10" class="global__image-outer-wrap global__image-outer-wrap--avatar-small"><div class="global__image-inner-wrap" style="background-image:url(avatar.jpg);"></div></a>
+				<div id="7IBue5D" class="comment__summary">
+					<div class="comment__author">
+						<i class="comment__collapse-button fa fa-minus-square-o"></i>
+						<i class="comment__expand-button fa fa-plus-square-o"></i>
+			<div class="comment__username"><a href="/user/TestUser10">TestUser10</a></div></div>
+					<div class="comment__display-state">
+						<div class="comment__description markdown markdown--resize-body">
+						<p>🐺 May the werewolves protect you. 🐺</p>
+						</div>
+					</div>
+				
+				<div class="comment__actions">
+					<div><span data-timestamp="1784495046">1 day</span> ago</div>
+			<a rel="nofollow noopener" href="/go/comment/7IBue5D" class="comment__actions__button">Permalink</a></div>
+				<div class="comment__collapse-state">
+					<div class="comment__description markdown markdown--resize-body"><p>Comment has been collapsed.</p></div>
+				</div>
+			</div>
+			
+						</div>
+						<div class="comment__children">
+							
+						</div>
+					</div>
+				
+					<div data-comment-id="64483625" class="comment">
+						<div class="ajax comment__parent">
+							<a href="/user/TestUser25" class="global__image-outer-wrap global__image-outer-wrap--avatar-small"><div class="global__image-inner-wrap" style="background-image:url(avatar.jpg);"></div></a>
+				<div id="l29hyQs" class="comment__summary">
+					<div class="comment__author">
+						<i class="comment__collapse-button fa fa-minus-square-o"></i>
+						<i class="comment__expand-button fa fa-plus-square-o"></i>
+			<div class="comment__username"><a href="/user/TestUser25">TestUser25</a></div></div>
+					<div class="comment__display-state">
+						<div class="comment__description markdown markdown--resize-body">
+						<p>Thank you~~~</p>
+						</div>
+					</div>
+				
+				<div class="comment__actions">
+					<div><span data-timestamp="1784506157">22 hours</span> ago</div>
+			<a rel="nofollow noopener" href="/go/comment/l29hyQs" class="comment__actions__button">Permalink</a></div>
+				<div class="comment__collapse-state">
+					<div class="comment__description markdown markdown--resize-body"><p>Comment has been collapsed.</p></div>
+				</div>
+			</div>
+			
+						</div>
+						<div class="comment__children">
+							
+						</div>
+					</div>
+				
+					<div data-comment-id="64483975" class="comment">
+						<div class="ajax comment__parent">
+							<a href="/user/TestUser24" class="global__image-outer-wrap global__image-outer-wrap--avatar-small"><div class="global__image-inner-wrap" style="background-image:url(avatar.jpg);"></div></a>
+				<div id="tQFybkP" class="comment__summary">
+					<div class="comment__author">
+						<i class="comment__collapse-button fa fa-minus-square-o"></i>
+						<i class="comment__expand-button fa fa-plus-square-o"></i>
+			<div class="comment__username"><a href="/user/TestUser24">TestUser24</a></div></div>
+					<div class="comment__display-state">
+						<div class="comment__description markdown markdown--resize-body">
+						<p>thks for chance</p>
+						</div>
+					</div>
+				
+				<div class="comment__actions">
+					<div><span data-timestamp="1784533316">14 hours</span> ago</div>
+			<a rel="nofollow noopener" href="/go/comment/tQFybkP" class="comment__actions__button">Permalink</a></div>
+				<div class="comment__collapse-state">
+					<div class="comment__description markdown markdown--resize-body"><p>Comment has been collapsed.</p></div>
+				</div>
+			</div>
+			
+						</div>
+						<div class="comment__children">
+							
+						</div>
+					</div>
+				
+					<div data-comment-id="64484162" class="comment">
+						<div class="ajax comment__parent">
+							<a href="/user/TestUser8" class="global__image-outer-wrap global__image-outer-wrap--avatar-small"><div class="global__image-inner-wrap" style="background-image:url(avatar.jpg);"></div></a>
+				<div id="2QNF35D" class="comment__summary">
+					<div class="comment__author">
+						<i class="comment__collapse-button fa fa-minus-square-o"></i>
+						<i class="comment__expand-button fa fa-plus-square-o"></i>
+			<div class="comment__username"><a href="/user/TestUser8">TestUser8</a></div></div>
+					<div class="comment__display-state">
+						<div class="comment__description markdown markdown--resize-body">
+						<p>Thank you for the giveaway!</p>
+						</div>
+					</div>
+				
+				<div class="comment__actions">
+					<div><span data-timestamp="1784546576">11 hours</span> ago</div>
+			<a rel="nofollow noopener" href="/go/comment/2QNF35D" class="comment__actions__button">Permalink</a></div>
+				<div class="comment__collapse-state">
+					<div class="comment__description markdown markdown--resize-body"><p>Comment has been collapsed.</p></div>
+				</div>
+			</div>
+			
+						</div>
+						<div class="comment__children">
+							
+						</div>
+					</div>
+				
+					<div data-comment-id="64484546" class="comment">
+						<div class="ajax comment__parent">
+							<a href="/user/TestUser16" class="global__image-outer-wrap global__image-outer-wrap--avatar-small"><div class="global__image-inner-wrap" style="background-image:url(avatar.jpg);"></div></a>
+				<div id="tRcHAql" class="comment__summary">
+					<div class="comment__author">
+						<i class="comment__collapse-button fa fa-minus-square-o"></i>
+						<i class="comment__expand-button fa fa-plus-square-o"></i>
+			<div class="comment__username"><a href="/user/TestUser16">TestUser16</a></div></div>
+					<div class="comment__display-state">
+						<div class="comment__description markdown markdown--resize-body">
+						<p>Thanks</p>
+						</div>
+					</div>
+				
+				<div class="comment__actions">
+					<div><span data-timestamp="1784562581">6 hours</span> ago</div>
+			<a rel="nofollow noopener" href="/go/comment/tRcHAql" class="comment__actions__button">Permalink</a></div>
+				<div class="comment__collapse-state">
+					<div class="comment__description markdown markdown--resize-body"><p>Comment has been collapsed.</p></div>
+				</div>
+			</div>
+			
+						</div>
+						<div class="comment__children">
+							
+						</div>
+					</div>
+				
+					<div data-comment-id="64484857" class="comment">
+						<div class="ajax comment__parent">
+							<a href="/user/TestUser21" class="global__image-outer-wrap global__image-outer-wrap--avatar-small"><div class="global__image-inner-wrap" style="background-image:url(avatar.jpg);"></div></a>
+				<div id="uJFMzNy" class="comment__summary">
+					<div class="comment__author">
+						<i class="comment__collapse-button fa fa-minus-square-o"></i>
+						<i class="comment__expand-button fa fa-plus-square-o"></i>
+			<div class="comment__username"><a href="/user/TestUser21">TestUser21</a></div></div>
+					<div class="comment__display-state">
+						<div class="comment__description markdown markdown--resize-body">
+						<p>Thanks mate</p>
+						</div>
+					</div>
+				
+				<div class="comment__actions">
+					<div><span data-timestamp="1784572040">4 hours</span> ago</div>
+			<a rel="nofollow noopener" href="/go/comment/uJFMzNy" class="comment__actions__button">Permalink</a></div>
+				<div class="comment__collapse-state">
+					<div class="comment__description markdown markdown--resize-body"><p>Comment has been collapsed.</p></div>
+				</div>
+			</div>
+			
+						</div>
+						<div class="comment__children">
+							
+						</div>
+					</div>
+				</div><div class="pagination"><div class="pagination__results">Displaying <strong>1</strong> to <strong>6</strong></div></div><div class="notification notification--warning notification--margin-top"><i class="fa fa-warning"></i> You do not have permission to comment on giveaways.</div>							<div class="widget-container widget-container--margin-top" style="margin-top: 50px;">
+								<div class="widget-container">
+									<div>
+										<div class="block_header">
+											<a href="/discussions/deals" class="block_header_text">Deals</a>
+											<a href="/discussions/deals" class="block_header_link">View More</a>
+										</div>
+										<div class="table">
+											<div class="table__rows">
+												
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser6" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/aurW8/fanatical-into-games-charity-bundle-2026">[Fanatical] Into Games Charity Bundle 2026🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/aurW8/fanatical-into-games-charity-bundle-2026">35 Comments</a> - Last post <span data-timestamp="1784577738">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser3">TestUser3</a><a class="icon-green table__last-comment-icon" href="/go/comment/o16Lcux"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser6" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/pNPjg/humble-bundle-even-steamier-sakura-special">[Humble Bundle] Even Steamier Sakura Special 🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/pNPjg/humble-bundle-even-steamier-sakura-special">31 Comments</a> - Last post <span data-timestamp="1784569064">4 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser1">TestUser1</a><a class="icon-green table__last-comment-icon" href="/go/comment/k8I0irk"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser6" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/7sWIx/green-man-gaming-lego-at-the-movies">[Green Man Gaming] LEGO At the Movies🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/7sWIx/green-man-gaming-lego-at-the-movies">31 Comments</a> - Last post <span data-timestamp="1784566969">5 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser9">TestUser9</a><a class="icon-green table__last-comment-icon" href="/go/comment/kgfEoJ5"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser26" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/EhJvw/where-are-those-giveaways-coming-from">Where are those giveaways coming from?</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/EhJvw/where-are-those-giveaways-coming-from">18,482 Comments</a> - Last post <span data-timestamp="1784563343">6 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser13">TestUser13</a><a class="icon-green table__last-comment-icon" href="/go/comment/CSPqZWl"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser18" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/jZ2C8/free-android-mobile-games-from-google-play">free android mobile games from google play</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/jZ2C8/free-android-mobile-games-from-google-play">1,293 Comments</a> - Last post <span data-timestamp="1784559987">7 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser7">TestUser7</a><a class="icon-green table__last-comment-icon" href="/go/comment/WiFZbh8"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser6" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/zIYa7/humble-bundle-2k-megahits-2026-bundle">[Humble Bundle] 2k Megahits 2026 Bundle🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/zIYa7/humble-bundle-2k-megahits-2026-bundle">28 Comments</a> - Last post <span data-timestamp="1784499742">1 day</span> ago by <a class="table__column__secondary-link" href="/user/TestUser2">TestUser2</a><a class="icon-green table__last-comment-icon" href="/go/comment/mpuzWLw"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser6" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/UBxEd/fanatical-build-your-own-best-of-cozy-bundle">[Fanatical] Build your own Best of Cozy Bundle 🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/UBxEd/fanatical-build-your-own-best-of-cozy-bundle">12 Comments</a> - Last post <span data-timestamp="1784488597">1 day</span> ago by <a class="table__column__secondary-link" href="/user/TestUser6">TestUser6</a><a class="icon-green table__last-comment-icon" href="/go/comment/1KdtSun"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+															</div>
+										</div>
+									</div>
+								</div>
+								<div class="widget-container">
+									<div>
+										<div class="block_header">
+											<a href="/discussions" class="block_header_text">Discussions</a>
+											<a href="/discussions" class="block_header_link">View More</a>
+										</div>
+										<div class="table">
+											<div class="table__rows">
+												
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser23" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/5k5Oq/site-twenty-tent-puzzles">Site Twenty: Tent puzzles</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/5k5Oq/site-twenty-tent-puzzles">125 Comments</a> - Last post <span data-timestamp="1784586812">2 minutes</span> ago by <a class="table__column__secondary-link" href="/user/TestUser30">TestUser30</a><a class="icon-green table__last-comment-icon" href="/go/comment/rxfvWWa"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser12" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/Xw94G/10-years-of-steamgifts">10 years of SteamGifts</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Xw94G/10-years-of-steamgifts">57 Comments</a> - Last post <span data-timestamp="1784585579">23 minutes</span> ago by <a class="table__column__secondary-link" href="/user/TestUser19">TestUser19</a><a class="icon-green table__last-comment-icon" href="/go/comment/e4ZjVzx"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser22" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/b736C/tool-sgtools-full-rewrite">[Tool] SGTools (Full Rewrite!)</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/b736C/tool-sgtools-full-rewrite">7,340 Comments</a> - Last post <span data-timestamp="1784583810">52 minutes</span> ago by <a class="table__column__secondary-link" href="/user/TestUser17">TestUser17</a><a class="icon-green table__last-comment-icon" href="/go/comment/vR97Ssh"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser27" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/sG54G/lv3-12th-cakeday-train-ends-july-29th">[Lv3+] 12th cakeday train (ends July 29th)</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/sG54G/lv3-12th-cakeday-train-ends-july-29th">111 Comments</a> - Last post <span data-timestamp="1784583248">1 hour</span> ago by <a class="table__column__secondary-link" href="/user/TestUser4">TestUser4</a><a class="icon-green table__last-comment-icon" href="/go/comment/BVJGqUB"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser29" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/NIHP5/guess-the-game-3-screenshot-boogaloo">Guess the Game 3: Screenshot Boogaloo</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/NIHP5/guess-the-game-3-screenshot-boogaloo">18,692 Comments</a> - Last post <span data-timestamp="1784582472">1 hour</span> ago by <a class="table__column__secondary-link" href="/user/TestUser20">TestUser20</a><a class="icon-green table__last-comment-icon" href="/go/comment/tzIzwHI"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser11" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/YrsP3/fbi-seeks-info-from-gamers-who-installed-malware-from-steam">FBI Seeks Info from Gamers Who Installed Malwar...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/YrsP3/fbi-seeks-info-from-gamers-who-installed-malware-from-steam">11 Comments</a> - Last post <span data-timestamp="1784579743">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser28">TestUser28</a><a class="icon-green table__last-comment-icon" href="/go/comment/9pQisSs"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser15" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/9Yqmg/14th-cakeday-event-small-train-will-add-more-later-this-week">14th Cakeday Event - Small Train (Will Add More...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/9Yqmg/14th-cakeday-event-small-train-will-add-more-later-this-week">95 Comments</a> - Last post <span data-timestamp="1784579553">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser5">TestUser5</a><a class="icon-green table__last-comment-icon" href="/go/comment/5YU0DJV"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+															</div>
+										</div>
+									</div>
+								</div>
+							</div>
+												</div>
+				</div>
+			</div>
+		</div>
+				<footer>
+			<div class="footer_inner_wrap">
+				<div class="footer_columns">
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-gift"></i>
+							<div class="footer_column_name">SteamGifts</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/">Giveaways</a>
+							<a class="footer_column_link" href="/discussions/deals">Deals</a>
+							<a class="footer_column_link" href="/discussions">Discussions</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-file-text-o"></i>
+							<div class="footer_column_name">Browse</div>
+						</div>
+						<div class="footer_column_links">
+														<a class="footer_column_link" href="/archive">Giveaway Archive</a>
+							<a class="footer_column_link" href="/roles">User Roles</a>
+							<a class="footer_column_link" href="/users">User List</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-question-circle"></i>
+							<div class="footer_column_name">Help</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/about/guidelines">Guidelines</a>
+							<a class="footer_column_link" href="/about/faq">FAQ</a>
+							<a class="footer_column_link" href="/about/comment-formatting">Comment Formatting</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-gavel"></i>
+							<div class="footer_column_name">Legal</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/legal/privacy-policy">Privacy Policy</a>
+							<a class="footer_column_link" href="/legal/cookie-policy">Cookie Policy</a>
+							<a class="footer_column_link" href="/legal/terms-of-service">Terms of Service</a>
+						</div>
+					</div>
+				</div>
+				<div class="footer_lower">
+					<div class="footer_steam">
+						<div>Powered by</div>
+						<a class="footer_steam_logo" href="https://store.steampowered.com" target="_blank" rel="nofollow noopener">
+							<i class="fa fa-steam"></i>
+							<div>Steam</div>
+						</a>
+					</div>
+					<div class="footer_sites">
+						<a title="Steam Trading" href="https://www.steamtrades.com">SteamTrades.com</a>
+						<a title="Free Steam Keys and Giveaways" href="https://www.steamgifts.com">SteamGifts.com</a>
+					</div>
+				</div>
+			</div>
+		</footer>
+	</body>
+</html>

--- a/backend/tests/fixtures/giveaway_page_description.html
+++ b/backend/tests/fixtures/giveaway_page_description.html
@@ -1,0 +1,456 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+						<link rel="shortcut icon" href="https://cdn.steamgifts.com/img/favicon.ico">
+		<title>Golf VS Zombies</title>
+		<!-- Google Fonts -->
+		<link rel="preconnect" href="https://fonts.gstatic.com">
+		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600;700&family=Roboto+Mono&display=swap" rel="stylesheet">
+		<!-- Include FontAwesome -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+		<!-- Include CSS -->
+		<link rel="stylesheet" href="https://cdn.steamgifts.com/css/bundle-v10.css">
+		<!-- Include Scripts -->
+		
+		
+		<meta name="viewport" content="width=1200">
+		
+							<style>
+				.adsbygoogle[data-ad-status="unfilled"], .adsbygoogle:empty {
+					height: 0 !important;
+				}
+			</style>
+			
+						
+	</head>
+	<body>
+					<div class="lightbox hide">
+				<div class="lightbox-header">
+					<div class="lightbox-header-description">
+						<div class="lightbox-header-description-name"></div>
+						<div class="lightbox-header-description-count"></div>
+					</div>
+					<div class="lightbox-header-icons">
+						<i data-category="images" class="lightbox-header-icon fa fa-camera"></i>
+						<i data-category="videos" class="lightbox-header-icon fa fa-video-camera"></i>
+						<i class="lightbox-header-icon lightbox-header-icon--close fa fa-times"></i>
+					</div>
+				</div>
+				<div class="lightbox-status lightbox-status--loading">
+					<div>
+						<div class="lightbox-status-icon"><i class="fa fa-cog fa-spin"></i></div>
+						<div class="lightbox-status-text">Please wait</div>
+					</div>
+				</div>
+				<div class="lightbox-status lightbox-status--empty">
+					<div>
+						<div class="lightbox-status-icon"><i class="fa fa-picture-o"></i></div>
+						<div class="lightbox-status-text">No results</div>
+					</div>
+				</div>
+				<div class="lightbox-content">
+					<div class="lightbox-content-nav">
+						<div class="lightbox-content-nav-btn lightbox-content-nav-btn--prev">
+							<div class="lightbox-content-nav-btn-icon"><i class="fa fa-angle-left"></i></div>
+						</div>
+						<div class="lightbox-content-nav-btn lightbox-content-nav-btn--next">
+							<div class="lightbox-content-nav-btn-icon"><i class="fa fa-angle-right"></i></div>
+						</div>
+					</div>
+					<div class="lightbox-content-image"></div>
+				</div>
+				<div class="lightbox-footer-outer">
+					<div class="lightbox-footer-inner">
+						<div class="lightbox-thumbnails"></div>
+					</div>
+				</div>
+			</div>
+					<header>
+			<nav>
+									<div class="nav__left-container">
+						<div class="nav__button-container">
+							<div class="nav__relative-dropdown is-hidden">
+								<div class="nav__absolute-dropdown">
+									<a class="nav__row" href="/giveaways/wishlist">
+										<i class="icon-blue fa fa-fw fa-users"></i>
+										<div class="nav__row__summary">
+											<p class="nav__row__summary__name">Community Wishlist</p>
+											<p class="nav__row__summary__description">Search for new games to share.</p>
+										</div>
+									</a>							
+								</div>
+							</div>	
+							<a class="nav__button nav__button--is-dropdown" href="/">Giveaways</a>
+							<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+						</div>
+												<div class="nav__button-container">
+							<a class="nav__button" href="/discussions/deals">Deals</a>
+						</div>
+						<div class="nav__button-container">
+							<a class="nav__button" href="/discussions">Discussions</a>
+						</div>
+						<div class="nav__button-container">
+							<div class="nav__relative-dropdown is-hidden">
+								<div class="nav__absolute-dropdown">
+									<a class="nav__row" href="/about/guidelines">
+										<i class="icon-blue fa fa-fw fa-file-text-o"></i>
+										<div class="nav__row__summary">
+											<p class="nav__row__summary__name">Guidelines</p>
+											<p class="nav__row__summary__description">Community rules and guidelines.</p>
+										</div>
+									</a>
+									<a class="nav__row" href="/about/faq">
+										<i class="icon-grey fa fa-fw fa-question-circle"></i>
+										<div class="nav__row__summary">
+											<p class="nav__row__summary__name">FAQ</p>
+											<p class="nav__row__summary__description">Frequently asked questions.</p>
+										</div>
+									</a>
+									<a class="nav__row" href="/about/comment-formatting">
+										<i class="icon-red fa fa-fw fa-code"></i>
+										<div class="nav__row__summary">
+											<p class="nav__row__summary__name">Comment Formatting</p>
+											<p class="nav__row__summary__description">Syntax for writing comments.</p>
+										</div>
+									</a>
+								</div>
+							</div>	
+							<a class="nav__button nav__button--is-dropdown" href="/about/faq">Help</a>
+							<div class="nav__button nav__button--is-dropdown-arrow"><i class="fa fa-angle-down"></i></div>
+						</div>
+					</div>
+					<div class="nav__right-container">
+													<div class="nav__button-container">
+							<a href="https://steamcommunity.com/openid/login?openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&amp;openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&amp;openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&amp;openid.mode=checkid_setup&amp;openid.return_to=https%3A%2F%2Fwww.steamgifts.com%2Fgiveaway%2FOAQNc%2Fgolf-vs-zombies" rel="nofollow" class="nav__sits"><i class="fa fa-steam"></i> Sign in through STEAM</a>
+							</div>
+												</div>
+								</nav>
+		</header>
+		
+			<div class="featured__container">
+				<div class="featured__outer-wrap featured__outer-wrap--giveaway" style="background-color:rgb(89,60,35)">
+					<div class="featured__inner-wrap">
+						<a href="https://store.steampowered.com/app/2330380?utm_source=SteamGifts" rel="nofollow noopener" target="_blank" class="global__image-outer-wrap global__image-outer-wrap--game-large">
+							<img src="https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2330380/header_292x136.jpg?t=1781520684" />
+						</a>
+						<div class="featured__summary">
+							<div class="featured__heading">
+								<div class="featured__heading__medium">Golf VS Zombies</div>
+								
+								<div class="featured__heading__small">(10P)</div><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-steam&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Steam Store&quot;}]}]}" rel="nofollow noopener" target="_blank" href="https://store.steampowered.com/app/2330380?utm_source=SteamGifts"><i class="fa fa-fw fa-steam"></i></a><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-camera&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;Screenshots / Videos&quot;}]}]}" data-lightbox-id="4230183781"><i class="fa fa-fw fa-camera"></i></a><a data-ui-tooltip="{&quot;rows&quot;:[{&quot;icon&quot; : [{&quot;class&quot; : &quot;fa-search&quot;, &quot;color&quot; : &quot;#84cfda&quot;}], &quot;columns&quot;:[{&quot;name&quot; : &quot;More Giveaways&quot;}]}]}" title="Free Steam Giveaways and Keys for Golf VS Zombies" href="/game/QcIzE/golf-vs-zombies"><i class="fa fa-fw fa-search"></i></a>
+							</div>
+							<div class="featured__columns">				
+								<div class="featured__column"><i style="color:rgb(204,148,102);" class="fa fa-clock-o"></i> <span data-timestamp="1784588400">24 minutes</span> remaining</div>
+								<div class="featured__column featured__column--width-fill text-right"><span data-timestamp="1783461734">1 week</span> ago by <a style="color:rgb(204,148,102);" href="/user/TestUser2">TestUser2</a></div><div class="featured__column featured__column--contributor-level featured__column--contributor-level--negative" title="Contributor Level">Level 6+</div><a href="/user/TestUser2" class="featured_giveaway_image_avatar" style="background-image:url(avatar.jpg);"></a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>		<div class="page__outer-wrap">
+			<div class="page__inner-wrap">
+				<div class="widget-container">
+					<div class="sidebar" style="width: 300px; min-width: 300px;">
+						<a href="https://steamcommunity.com/openid/login?openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&amp;openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&amp;openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&amp;openid.mode=checkid_setup&amp;openid.return_to=https%3A%2F%2Fwww.steamgifts.com%2Fgiveaway%2FOAQNc%2Fgolf-vs-zombies" rel="nofollow" class="sidebar__error"><i class="fa fa-steam"></i> Sign in to Enter Giveaway</a>
+				<div class="sidebar__search-container">
+					<input class="sidebar__search-input" name="search-query" type="text" placeholder="Search..." value="" />
+					<i class="fa fa-search"></i>
+				</div>
+				<div class="sidebar__heading">Giveaway</div><ul class="sidebar__navigation">
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item is-selected"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaway/OAQNc/golf-vs-zombies"><i class="fa fa-caret-right"></i> 
+									<div class="sidebar__navigation__item__name">Comments</div>
+									<div class="sidebar__navigation__item__underline"></div><div class="sidebar__navigation__item__count">0</div>
+								</a>
+							</li>
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaway/OAQNc/golf-vs-zombies/entries">
+									<div class="sidebar__navigation__item__name">Entries</div>
+									<div class="sidebar__navigation__item__underline"></div><div class="sidebar__navigation__item__count live__entry-count">562</div>
+								</a>
+							</li></ul><div class="sidebar__heading">Tools</div><ul class="sidebar__navigation">
+							<li style="display: flex; align-items: center;" class="sidebar__navigation__item"><a style="flex: 1;" class="sidebar__navigation__item__link" href="/giveaway/OAQNc/golf-vs-zombies/stats">
+									<div class="sidebar__navigation__item__name">Stats</div>
+									<div class="sidebar__navigation__item__underline"></div>
+								</a>
+							</li></ul><div class="nqrncoicx"><a style=" margin: 25px 0 0 0;" class="fanatical_container hide vertical" target="_blank" rel="nofollow noopener" href="https://www.steamgifts.com/redirect?url=https%3A%2F%2Fwww.humblebundle.com%2Fgames%2F2k-megahits-2026-bundle"><img class="fanatical_img" src="https://hb.imgix.net/2ba4b565d865609b7e7e07e1302eff32629b0226.jpg?auto=compress,format&amp;fit=crop&amp;h=353&amp;w=616&amp;s=f18e2210926096360dc0432f148ca5bc" /><div class="fanatical_description"><div><span class="fanatical_name">2K Megahits 2026 Bundle</span></div><div class="fanatical_date"><i class="fa fa-clock-o"></i><div>Started <span data-timestamp="1784311200">3 days</span> ago</div></div></div><div class="fanatical_summary"><div class="fanatical_icons"><div class="fanatical_icon" style="background-image: url(avatar.jpg);"></div></div><div class="fanatical_pricing">$15.00</div></div></a>
+						<div style="padding-top: 35px;">
+							<!-- sg_giveaway_top_responsive -->
+							<ins class="adsbygoogle"
+								 style="display:block"
+								 data-ad-client="ca-pub-7519145598166360"
+								 data-ad-slot="9451237317"
+								 data-ad-format="auto"
+								 data-full-width-responsive="true"></ins>
+							
+						</div>
+					</div>						
+					</div>
+					<div>
+						<div class="page__heading"><div class="page__heading__breadcrumbs">Description</div></div>								<div class="page__description">
+																		<div class="page__description__display-state">
+										<div class="markdown markdown--resize-body"><p>Mystery Box Bundle - Holiday Edition, Fanatical</p></div>									</div>
+								</div>
+														<div class="page__heading">
+							<div class="page__heading__breadcrumbs"><a href="/giveaway/OAQNc/golf-vs-zombies">0 Comments</a></div>						</div>
+						<div class="pagination pagination--no-results"><div class="pagination__results">No results were found.</div></div><div class="notification notification--warning notification--margin-top"><i class="fa fa-warning"></i> You do not have permission to comment on giveaways.</div>							<div class="widget-container widget-container--margin-top" style="margin-top: 50px;">
+								<div class="widget-container">
+									<div>
+										<div class="block_header">
+											<a href="/discussions/deals" class="block_header_text">Deals</a>
+											<a href="/discussions/deals" class="block_header_link">View More</a>
+										</div>
+										<div class="table">
+											<div class="table__rows">
+												
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser7" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/aurW8/fanatical-into-games-charity-bundle-2026">[Fanatical] Into Games Charity Bundle 2026🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/aurW8/fanatical-into-games-charity-bundle-2026">35 Comments</a> - Last post <span data-timestamp="1784577738">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser4">TestUser4</a><a class="icon-green table__last-comment-icon" href="/go/comment/o16Lcux"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser7" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/pNPjg/humble-bundle-even-steamier-sakura-special">[Humble Bundle] Even Steamier Sakura Special 🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/pNPjg/humble-bundle-even-steamier-sakura-special">31 Comments</a> - Last post <span data-timestamp="1784569064">4 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser1">TestUser1</a><a class="icon-green table__last-comment-icon" href="/go/comment/k8I0irk"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser7" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/7sWIx/green-man-gaming-lego-at-the-movies">[Green Man Gaming] LEGO At the Movies🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/7sWIx/green-man-gaming-lego-at-the-movies">31 Comments</a> - Last post <span data-timestamp="1784566969">5 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser9">TestUser9</a><a class="icon-green table__last-comment-icon" href="/go/comment/kgfEoJ5"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser20" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/EhJvw/where-are-those-giveaways-coming-from">Where are those giveaways coming from?</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/EhJvw/where-are-those-giveaways-coming-from">18,482 Comments</a> - Last post <span data-timestamp="1784563343">6 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser12">TestUser12</a><a class="icon-green table__last-comment-icon" href="/go/comment/CSPqZWl"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser15" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/jZ2C8/free-android-mobile-games-from-google-play">free android mobile games from google play</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/jZ2C8/free-android-mobile-games-from-google-play">1,293 Comments</a> - Last post <span data-timestamp="1784559987">7 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser8">TestUser8</a><a class="icon-green table__last-comment-icon" href="/go/comment/WiFZbh8"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser7" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/zIYa7/humble-bundle-2k-megahits-2026-bundle">[Humble Bundle] 2k Megahits 2026 Bundle🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/zIYa7/humble-bundle-2k-megahits-2026-bundle">28 Comments</a> - Last post <span data-timestamp="1784499742">1 day</span> ago by <a class="table__column__secondary-link" href="/user/TestUser3">TestUser3</a><a class="icon-green table__last-comment-icon" href="/go/comment/mpuzWLw"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser7" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/UBxEd/fanatical-build-your-own-best-of-cozy-bundle">[Fanatical] Build your own Best of Cozy Bundle 🐶</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/UBxEd/fanatical-build-your-own-best-of-cozy-bundle">12 Comments</a> - Last post <span data-timestamp="1784488597">1 day</span> ago by <a class="table__column__secondary-link" href="/user/TestUser7">TestUser7</a><a class="icon-green table__last-comment-icon" href="/go/comment/1KdtSun"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+															</div>
+										</div>
+									</div>
+								</div>
+								<div class="widget-container">
+									<div>
+										<div class="block_header">
+											<a href="/discussions" class="block_header_text">Discussions</a>
+											<a href="/discussions" class="block_header_link">View More</a>
+										</div>
+										<div class="table">
+											<div class="table__rows">
+												
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser19" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/5k5Oq/site-twenty-tent-puzzles">Site Twenty: Tent puzzles</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/5k5Oq/site-twenty-tent-puzzles">125 Comments</a> - Last post <span data-timestamp="1784586812">2 minutes</span> ago by <a class="table__column__secondary-link" href="/user/TestUser24">TestUser24</a><a class="icon-green table__last-comment-icon" href="/go/comment/rxfvWWa"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser11" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/Xw94G/10-years-of-steamgifts">10 years of SteamGifts</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/Xw94G/10-years-of-steamgifts">57 Comments</a> - Last post <span data-timestamp="1784585579">22 minutes</span> ago by <a class="table__column__secondary-link" href="/user/TestUser16">TestUser16</a><a class="icon-green table__last-comment-icon" href="/go/comment/e4ZjVzx"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser18" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/b736C/tool-sgtools-full-rewrite">[Tool] SGTools (Full Rewrite!)</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/b736C/tool-sgtools-full-rewrite">7,340 Comments</a> - Last post <span data-timestamp="1784583810">52 minutes</span> ago by <a class="table__column__secondary-link" href="/user/TestUser14">TestUser14</a><a class="icon-green table__last-comment-icon" href="/go/comment/vR97Ssh"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser21" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/sG54G/lv3-12th-cakeday-train-ends-july-29th">[Lv3+] 12th cakeday train (ends July 29th)</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/sG54G/lv3-12th-cakeday-train-ends-july-29th">111 Comments</a> - Last post <span data-timestamp="1784583248">1 hour</span> ago by <a class="table__column__secondary-link" href="/user/TestUser5">TestUser5</a><a class="icon-green table__last-comment-icon" href="/go/comment/BVJGqUB"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser23" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/NIHP5/guess-the-game-3-screenshot-boogaloo">Guess the Game 3: Screenshot Boogaloo</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/NIHP5/guess-the-game-3-screenshot-boogaloo">18,692 Comments</a> - Last post <span data-timestamp="1784582472">1 hour</span> ago by <a class="table__column__secondary-link" href="/user/TestUser17">TestUser17</a><a class="icon-green table__last-comment-icon" href="/go/comment/tzIzwHI"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser10" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><a class="homepage_table_column_heading" href="/discussion/YrsP3/fbi-seeks-info-from-gamers-who-installed-malware-from-steam">FBI Seeks Info from Gamers Who Installed Malwar...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/YrsP3/fbi-seeks-info-from-gamers-who-installed-malware-from-steam">11 Comments</a> - Last post <span data-timestamp="1784579743">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser22">TestUser22</a><a class="icon-green table__last-comment-icon" href="/go/comment/9pQisSs"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+				
+					<div class="table__row-outer-wrap">
+						<div class="table__row-inner-wrap">
+							<div>
+								<a class="table_image_avatar" href="/user/TestUser13" style="background-image:url(avatar.jpg);"></a>
+							</div>
+							<div class="table__column--width-fill">
+								<h3 style="margin-bottom: 2px;"><i class="icon-heading fa fa-align-left"></i><a class="homepage_table_column_heading" href="/discussion/9Yqmg/14th-cakeday-event-small-train-will-add-more-later-this-week">14th Cakeday Event - Small Train (Will Add More...</a></h3>
+								<p><a class="table__column__secondary-link" href="/discussion/9Yqmg/14th-cakeday-event-small-train-will-add-more-later-this-week">95 Comments</a> - Last post <span data-timestamp="1784579553">2 hours</span> ago by <a class="table__column__secondary-link" href="/user/TestUser6">TestUser6</a><a class="icon-green table__last-comment-icon" href="/go/comment/5YU0DJV"><i class="fa fa-chevron-circle-right"></i></a></p>
+							</div>
+						</div>
+					</div>
+															</div>
+										</div>
+									</div>
+								</div>
+							</div>
+												</div>
+				</div>
+			</div>
+		</div>
+				<footer>
+			<div class="footer_inner_wrap">
+				<div class="footer_columns">
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-gift"></i>
+							<div class="footer_column_name">SteamGifts</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/">Giveaways</a>
+							<a class="footer_column_link" href="/discussions/deals">Deals</a>
+							<a class="footer_column_link" href="/discussions">Discussions</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-file-text-o"></i>
+							<div class="footer_column_name">Browse</div>
+						</div>
+						<div class="footer_column_links">
+														<a class="footer_column_link" href="/archive">Giveaway Archive</a>
+							<a class="footer_column_link" href="/roles">User Roles</a>
+							<a class="footer_column_link" href="/users">User List</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-question-circle"></i>
+							<div class="footer_column_name">Help</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/about/guidelines">Guidelines</a>
+							<a class="footer_column_link" href="/about/faq">FAQ</a>
+							<a class="footer_column_link" href="/about/comment-formatting">Comment Formatting</a>
+						</div>
+					</div>
+					<div class="footer_column">
+						<div class="footer_column_heading">
+							<i class="fa fa-gavel"></i>
+							<div class="footer_column_name">Legal</div>
+						</div>
+						<div class="footer_column_links">
+							<a class="footer_column_link" href="/legal/privacy-policy">Privacy Policy</a>
+							<a class="footer_column_link" href="/legal/cookie-policy">Cookie Policy</a>
+							<a class="footer_column_link" href="/legal/terms-of-service">Terms of Service</a>
+						</div>
+					</div>
+				</div>
+				<div class="footer_lower">
+					<div class="footer_steam">
+						<div>Powered by</div>
+						<a class="footer_steam_logo" href="https://store.steampowered.com" target="_blank" rel="nofollow noopener">
+							<i class="fa fa-steam"></i>
+							<div>Steam</div>
+						</a>
+					</div>
+					<div class="footer_sites">
+						<a title="Steam Trading" href="https://www.steamtrades.com">SteamTrades.com</a>
+						<a title="Free Steam Keys and Giveaways" href="https://www.steamgifts.com">SteamGifts.com</a>
+					</div>
+				</div>
+			</div>
+		</footer>
+	</body>
+</html>

--- a/backend/tests/scripts/fetch_giveaway_page.py
+++ b/backend/tests/scripts/fetch_giveaway_page.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Fetch a single giveaway page HTML for parser analysis / fixture refresh.
+
+Run this from the backend directory:
+    cd backend
+    source .venv/bin/activate
+    python tests/scripts/fetch_giveaway_page.py <giveaway_code>
+
+The HTML will be saved to tests/scripts/output/giveaway_page.html.
+Scrub usernames, avatar URLs and xsrf tokens before committing as a fixture
+(see tests/fixtures/giveaway_page.html).
+"""
+
+import asyncio
+import os
+import sys
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from sqlalchemy import create_engine, text
+
+from utils.steamgifts_client import SteamGiftsClient
+
+
+def get_session_from_db():
+    """Read PHPSESSID and user_agent from the database."""
+    db_path = os.path.join(os.path.dirname(__file__), "..", "..", "data", "steamselfgifter.db")
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT phpsessid, user_agent FROM settings LIMIT 1"))
+        row = result.fetchone()
+        if row:
+            return row[0], row[1]
+    return None, None
+
+
+async def main():
+    if len(sys.argv) != 2:
+        print("Usage: python tests/scripts/fetch_giveaway_page.py <giveaway_code>")
+        sys.exit(1)
+    code = sys.argv[1]
+
+    phpsessid, user_agent = get_session_from_db()
+    if not phpsessid:
+        print("No PHPSESSID found in the database — configure it in the app settings first.")
+        sys.exit(1)
+
+    client = SteamGiftsClient(phpsessid=phpsessid, user_agent=user_agent)
+    await client.start()
+    try:
+        response = await client._get(f"{client.BASE_URL}/giveaway/{code}/")
+        out_dir = os.path.join(os.path.dirname(__file__), "output")
+        os.makedirs(out_dir, exist_ok=True)
+        out_path = os.path.join(out_dir, "giveaway_page.html")
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(response.text)
+        print(f"Saved {len(response.text)} bytes to {out_path}")
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/unit/test_eligibility.py
+++ b/backend/tests/unit/test_eligibility.py
@@ -30,6 +30,7 @@ from services.eligibility import (
     PRICE_BELOW_MIN,
     REVIEWS_BELOW_MIN,
     SCORE_BELOW_MIN,
+    UNSAFE,
     EligibilityCriteria,
     evaluate_eligibility,
 )
@@ -45,6 +46,7 @@ def _gw(**kw):
         end_time=NOW + timedelta(days=1),
         is_hidden=False,
         is_entered=False,
+        is_safe=None,
         is_wishlist=False,
         is_dlc=False,
         price=50,
@@ -83,6 +85,17 @@ def test_hidden():
 def test_entered():
     crit = EligibilityCriteria(min_price=10)
     assert evaluate_eligibility(_gw(is_entered=True), _game(), crit, NOW) == ENTERED
+
+
+def test_unsafe_and_borderline_excluded_unchecked_passes():
+    crit = EligibilityCriteria(min_price=10)
+    # is_safe False covers both unsafe and borderline verdicts
+    assert evaluate_eligibility(_gw(is_safe=False), _game(), crit, NOW) == UNSAFE
+    # Never-checked (NULL) and safe giveaways pass
+    assert evaluate_eligibility(_gw(is_safe=None), _game(), crit, NOW) == ELIGIBLE
+    assert evaluate_eligibility(_gw(is_safe=True), _game(), crit, NOW) == ELIGIBLE
+    # Safety exclusion also applies to wishlist/DLC bypass giveaways
+    assert evaluate_eligibility(_gw(is_wishlist=True, is_safe=False), None, crit, NOW) == UNSAFE
 
 
 def test_price_below_min():
@@ -206,11 +219,11 @@ async def _seed(session):
     ])
 
     def gw(code, price=50, game_id=1, end=future, hidden=False, entered=False,
-           wishlist=False, dlc=False):
+           wishlist=False, dlc=False, safe=None):
         return Giveaway(
             code=code, url=f"http://x/{code}", game_name=code, price=price,
             end_time=end, game_id=game_id, is_hidden=hidden, is_entered=entered,
-            is_wishlist=wishlist, is_dlc=dlc,
+            is_wishlist=wishlist, is_dlc=dlc, is_safe=safe,
         )
 
     session.add_all([
@@ -232,6 +245,11 @@ async def _seed(session):
         gw("wishhidden", game_id=1, hidden=True, wishlist=True),  # hidden beats wishlist
         # DLC row: bypasses filters only when dlc_priority is on
         gw("dlcbad", price=1, game_id=2, dlc=True),            # fails price + score filters
+        # Safety rows: is_safe False (unsafe or borderline) is excluded even
+        # for wishlist; explicit True and NULL (unchecked) pass
+        gw("unsafegw", price=80, game_id=1, safe=False),
+        gw("wishunsafe", price=80, game_id=1, wishlist=True, safe=False),
+        gw("safegw", price=80, game_id=1, safe=True),          # eligible
     ])
     await session.commit()
 

--- a/backend/tests/unit/test_services_giveaway_service.py
+++ b/backend/tests/unit/test_services_giveaway_service.py
@@ -693,12 +693,11 @@ async def test_check_giveaway_safety_safe(test_db, mock_sg_client, mock_game_ser
         # Mock safety check response
         mock_sg_client.check_giveaway_safety = AsyncMock(
             return_value={
+                "verdict": "safe",
                 "is_safe": True,
                 "safety_score": 100,
-                "bad_count": 0,
-                "good_count": 0,
-                "net_bad": 0,
                 "details": [],
+                "warning_comments": 0,
             }
         )
 
@@ -707,10 +706,11 @@ async def test_check_giveaway_safety_safe(test_db, mock_sg_client, mock_game_ser
         assert result["is_safe"] is True
         assert result["safety_score"] == 100
 
-        # Verify giveaway was updated
+        # Verify giveaway was updated, including the freshness timestamp
         giveaway = await service.giveaway_repo.get_by_code("AbCd1")
         assert giveaway.is_safe is True
         assert giveaway.safety_score == 100
+        assert giveaway.safety_checked_at is not None
 
 
 @pytest.mark.asyncio
@@ -731,12 +731,11 @@ async def test_check_giveaway_safety_unsafe(test_db, mock_sg_client, mock_game_s
         # Mock unsafe response
         mock_sg_client.check_giveaway_safety = AsyncMock(
             return_value={
+                "verdict": "unsafe",
                 "is_safe": False,
                 "safety_score": 20,
-                "bad_count": 4,
-                "good_count": 0,
-                "net_bad": 4,
                 "details": ["ban", "fake", "don't enter"],
+                "warning_comments": 0,
             }
         )
 
@@ -860,12 +859,11 @@ async def test_enter_giveaway_with_safety_check_safe(test_db, mock_sg_client, mo
         # Mock safety check - safe
         mock_sg_client.check_giveaway_safety = AsyncMock(
             return_value={
+                "verdict": "safe",
                 "is_safe": True,
                 "safety_score": 100,
-                "bad_count": 0,
-                "good_count": 0,
-                "net_bad": 0,
                 "details": [],
+                "warning_comments": 0,
             }
         )
         # Mock successful entry
@@ -900,12 +898,11 @@ async def test_enter_giveaway_with_safety_check_unsafe(test_db, mock_sg_client, 
         # Mock safety check - unsafe
         mock_sg_client.check_giveaway_safety = AsyncMock(
             return_value={
+                "verdict": "unsafe",
                 "is_safe": False,
                 "safety_score": 20,
-                "bad_count": 4,
-                "good_count": 0,
-                "net_bad": 4,
                 "details": ["ban", "fake"],
+                "warning_comments": 0,
             }
         )
         # Mock game ID for hiding
@@ -927,6 +924,203 @@ async def test_enter_giveaway_with_safety_check_unsafe(test_db, mock_sg_client, 
         entries = await service.entry_repo.get_by_status("failed")
         assert len(entries) == 1
         assert "Unsafe giveaway" in entries[0].error_message
+
+
+@pytest.mark.asyncio
+async def test_enter_giveaway_with_safety_check_borderline_skips_without_hiding(
+    test_db, mock_sg_client, mock_game_service
+):
+    """Borderline verdicts skip the entry but never hide the giveaway."""
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        await service.giveaway_repo.create(
+            code="Bord1",
+            url="https://www.steamgifts.com/giveaway/Bord1/",
+            game_name="Suspicious Game",
+            price=50,
+        )
+        await session.commit()
+
+        mock_sg_client.check_giveaway_safety = AsyncMock(
+            return_value={
+                "verdict": "borderline",
+                "is_safe": False,
+                "safety_score": 80,
+                "details": ["\\bfake\\b"],
+                "warning_comments": 0,
+            }
+        )
+
+        entry = await service.enter_giveaway_with_safety_check("Bord1", "auto")
+
+        assert entry is None
+        mock_sg_client.enter_giveaway.assert_not_called()
+        mock_sg_client.hide_giveaway.assert_not_called()
+
+        # Giveaway stays visible (not hidden) but excluded from eligibility
+        giveaway = await service.giveaway_repo.get_by_code("Bord1")
+        assert giveaway.is_hidden is False
+        assert giveaway.is_safe is False
+
+        entries = await service.entry_repo.get_by_status("failed")
+        assert len(entries) == 1
+        assert "Borderline" in entries[0].error_message
+
+
+@pytest.mark.asyncio
+async def test_enter_giveaway_with_safety_check_fails_closed(
+    test_db, mock_sg_client, mock_game_service
+):
+    """A safety check error skips the giveaway instead of entering unchecked."""
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        await service.giveaway_repo.create(
+            code="Err01",
+            url="https://www.steamgifts.com/giveaway/Err01/",
+            game_name="Unreachable Game",
+            price=50,
+        )
+        await session.commit()
+
+        mock_sg_client.check_giveaway_safety = AsyncMock(side_effect=Exception("network down"))
+
+        entry = await service.enter_giveaway_with_safety_check("Err01", "auto")
+
+        assert entry is None
+        mock_sg_client.enter_giveaway.assert_not_called()
+
+        # Nothing recorded or flagged: the giveaway is retried next cycle
+        giveaway = await service.giveaway_repo.get_by_code("Err01")
+        assert giveaway.is_safe is None
+        entries = await service.entry_repo.get_by_status("failed")
+        assert len(entries) == 0
+
+
+@pytest.mark.asyncio
+async def test_enter_giveaway_with_safety_check_reuses_fresh_verdict(
+    test_db, mock_sg_client, mock_game_service
+):
+    """A fresh stored verdict is trusted without refetching the page."""
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        await service.giveaway_repo.create(
+            code="Fresh",
+            url="https://www.steamgifts.com/giveaway/Fresh/",
+            game_name="Recently Checked Game",
+            price=50,
+            is_safe=True,
+            safety_score=100,
+            safety_checked_at=utcnow(),
+        )
+        await session.commit()
+
+        mock_sg_client.check_giveaway_safety = AsyncMock()
+        mock_sg_client.enter_giveaway = AsyncMock(return_value=True)
+
+        entry = await service.enter_giveaway_with_safety_check("Fresh", "auto")
+
+        assert entry is not None
+        mock_sg_client.check_giveaway_safety.assert_not_called()
+        mock_sg_client.enter_giveaway.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_enter_giveaway_with_safety_check_rechecks_stale_verdict(
+    test_db, mock_sg_client, mock_game_service
+):
+    """A stale stored verdict triggers a fresh page check."""
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        await service.giveaway_repo.create(
+            code="Stale",
+            url="https://www.steamgifts.com/giveaway/Stale/",
+            game_name="Stale Verdict Game",
+            price=50,
+            is_safe=True,
+            safety_score=100,
+            safety_checked_at=utcnow() - timedelta(hours=48),
+        )
+        await session.commit()
+
+        mock_sg_client.check_giveaway_safety = AsyncMock(
+            return_value={
+                "verdict": "safe",
+                "is_safe": True,
+                "safety_score": 100,
+                "details": [],
+                "warning_comments": 0,
+            }
+        )
+        mock_sg_client.enter_giveaway = AsyncMock(return_value=True)
+
+        entry = await service.enter_giveaway_with_safety_check("Stale", "auto")
+
+        assert entry is not None
+        mock_sg_client.check_giveaway_safety.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sweep_unchecked_safety(test_db, mock_sg_client, mock_game_service):
+    """The sweep scores unchecked giveaways and hides outright traps."""
+    async with test_db() as session:
+        service = GiveawayService(session, mock_sg_client, mock_game_service)
+
+        future = utcnow() + timedelta(days=1)
+        for code, name in (("Swp01", "Fine Game"), ("Swp02", "Trap Game")):
+            await service.giveaway_repo.create(
+                code=code,
+                url=f"https://www.steamgifts.com/giveaway/{code}/",
+                game_name=name,
+                price=50,
+                end_time=future,
+            )
+        # Already-checked giveaway must not be re-swept
+        await service.giveaway_repo.create(
+            code="Swp03",
+            url="https://www.steamgifts.com/giveaway/Swp03/",
+            game_name="Checked Game",
+            price=50,
+            end_time=future,
+            is_safe=True,
+            safety_score=100,
+            safety_checked_at=utcnow(),
+        )
+        await session.commit()
+
+        verdicts = {
+            "Swp01": {
+                "verdict": "safe",
+                "is_safe": True,
+                "safety_score": 100,
+                "details": [],
+                "warning_comments": 0,
+            },
+            "Swp02": {
+                "verdict": "unsafe",
+                "is_safe": False,
+                "safety_score": 0,
+                "details": ["\\btrap\\b"],
+                "warning_comments": 0,
+            },
+        }
+        mock_sg_client.check_giveaway_safety = AsyncMock(side_effect=lambda c: verdicts[c])
+        mock_sg_client.get_giveaway_game_id = AsyncMock(return_value=12345)
+        mock_sg_client.hide_giveaway = AsyncMock(return_value=True)
+
+        counts = await service.sweep_unchecked_safety(limit=10, delay_min=0, delay_max=0)
+
+        assert counts == {"checked": 2, "safe": 1, "borderline": 0, "unsafe": 1, "errors": 0}
+        # The trap was hidden, the fine one wasn't
+        trap = await service.giveaway_repo.get_by_code("Swp02")
+        assert trap.is_hidden is True
+        fine = await service.giveaway_repo.get_by_code("Swp01")
+        assert fine.is_hidden is False
+        # All swept rows carry verdicts now
+        assert fine.is_safe is True and fine.safety_checked_at is not None
 
 
 # ==================== DLC Scanning Service Tests ====================

--- a/backend/tests/unit/test_steamgifts_parser.py
+++ b/backend/tests/unit/test_steamgifts_parser.py
@@ -119,7 +119,84 @@ class TestParserEdgeCases:
         assert clean["is_safe"] is True
         assert clean["safety_score"] == 100
 
-        trap = parser.check_page_safety(
-            "please do not enter this is fake and you will get a ban, bot trap"
+
+@pytest.fixture(scope="module")
+def comments_html() -> str:
+    return (FIXTURES / "giveaway_page.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def description_html() -> str:
+    return (FIXTURES / "giveaway_page_description.html").read_text(encoding="utf-8")
+
+
+class TestGiveawayPageFixtures:
+    """Structural regression tests against sanitized live giveaway pages.
+
+    giveaway_page.html: a real giveaway with 6 visible comments (plus
+    collapsed placeholders that must be excluded) and no description.
+    giveaway_page_description.html: a real giveaway with a description
+    and no comments. Refresh with tests/scripts/fetch_giveaway_page.py.
+    """
+
+    def test_comments_extracted_collapsed_excluded(self, comments_html):
+        texts = parser.extract_giveaway_texts(comments_html)
+        assert texts["description"] == ""
+        assert len(texts["comments"]) == 6
+        assert not any("collapsed" in c.lower() for c in texts["comments"])
+
+    def test_fixture_actually_contains_collapsed_placeholders(self, comments_html):
+        # Guard against a silently outdated fixture: the collapse-state blocks
+        # must be present for the exclusion assertion above to mean anything.
+        assert comments_html.count("comment__collapse-state") > 0
+
+    def test_description_extracted(self, description_html):
+        texts = parser.extract_giveaway_texts(description_html)
+        assert texts["description"] == "Mystery Box Bundle - Holiday Edition, Fanatical"
+        assert texts["comments"] == []
+
+    def test_both_real_pages_score_safe(self, comments_html, description_html):
+        assert parser.check_page_safety(comments_html)["verdict"] == "safe"
+        assert parser.check_page_safety(description_html)["verdict"] == "safe"
+
+
+class TestSafetyScoring:
+    def test_trap_description_unsafe(self):
+        result = parser.score_giveaway_safety(
+            "Do not enter, this is a bot trap, you will get banned", []
         )
-        assert trap["is_safe"] is False
+        assert result["verdict"] == "unsafe"
+        assert result["is_safe"] is False
+        assert result["safety_score"] < 50
+        assert result["details"]
+
+    def test_weak_word_borderline(self):
+        result = parser.score_giveaway_safety("these screenshots look fake", [])
+        assert result["verdict"] == "borderline"
+        assert result["safety_score"] == 80
+
+    def test_word_boundaries(self):
+        result = parser.score_giveaway_safety(
+            "urban banking robots and banners in abandoned bandit lands", []
+        )
+        assert result["verdict"] == "safe"
+        assert result["safety_score"] == 100
+
+    def test_comment_weight_capped(self):
+        warnings = ["do not enter, bot trap"] * 10
+        result = parser.score_giveaway_safety("", warnings)
+        # Cap keeps a comment pile-on at borderline, never outright unsafe
+        assert result["warning_comments"] == 10
+        assert result["verdict"] == "borderline"
+        assert result["safety_score"] == 60
+
+    def test_single_warning_comment_safe(self):
+        result = parser.score_giveaway_safety("", ["don't enter!!"])
+        assert result["verdict"] == "safe"
+        assert result["safety_score"] == 85
+
+    def test_empty_texts_safe(self):
+        result = parser.score_giveaway_safety("", [])
+        assert result["verdict"] == "safe"
+        assert result["safety_score"] == 100
+        assert result["warning_comments"] == 0

--- a/backend/tests/unit/test_utils_steamgifts_client.py
+++ b/backend/tests/unit/test_utils_steamgifts_client.py
@@ -542,93 +542,97 @@ async def test_client_without_session_raises_error(steamgifts_client):
 
 # ==================== Safety Detection Tests ====================
 
+def _giveaway_page(description: str = "", comments: tuple[str, ...] = ()) -> str:
+    """Minimal giveaway page in real SteamGifts structure."""
+    comment_html = "".join(
+        '<div class="comment__display-state">'
+        f'<div class="comment__description markdown"><p>{c}</p></div></div>'
+        for c in comments
+    )
+    description_html = (
+        '<div class="page__description"><div class="page__description__display-state">'
+        f'<div class="markdown markdown--resize-body"><p>{description}</p></div></div></div>'
+        if description
+        else ""
+    )
+    return (
+        "<html><body>"
+        '<nav class="nav">ban fake bot do not enter</nav>'  # chrome must be ignored
+        f"{description_html}{comment_html}"
+        "</body></html>"
+    )
+
+
 class TestSafetyDetection:
     """Tests for trap/scam detection functionality."""
 
-    def test_check_page_safety_clean_page(self, steamgifts_client):
-        """Test check_page_safety returns safe for clean pages."""
-        clean_html = """
-        <html>
-            <body>
-                <div class="giveaway">
-                    <h2>Portal 2 Giveaway</h2>
-                    <p>Enjoy this great game!</p>
-                </div>
-            </body>
-        </html>
-        """
+    def test_clean_page_is_safe(self, steamgifts_client):
+        result = steamgifts_client.check_page_safety(
+            _giveaway_page("Enjoy this great game, good luck everyone!")
+        )
 
-        result = steamgifts_client.check_page_safety(clean_html)
-
+        assert result["verdict"] == "safe"
         assert result["is_safe"] is True
         assert result["safety_score"] == 100
-        assert result["bad_count"] == 0
-        assert result["good_count"] == 0
         assert result["details"] == []
 
-    def test_check_page_safety_with_forbidden_words(self, steamgifts_client):
-        """Test check_page_safety detects forbidden words."""
-        unsafe_html = """
-        <html>
-            <body>
-                <div class="giveaway">
-                    <h2>Test Giveaway</h2>
-                    <p>Warning: don't enter this giveaway, it's fake!</p>
-                    <p>You will get a ban if you enter.</p>
-                </div>
-            </body>
-        </html>
-        """
+    def test_trap_description_is_unsafe(self, steamgifts_client):
+        result = steamgifts_client.check_page_safety(
+            _giveaway_page("Do not enter! This is a bot trap and you will get banned.")
+        )
 
-        result = steamgifts_client.check_page_safety(unsafe_html)
-
+        assert result["verdict"] == "unsafe"
         assert result["is_safe"] is False
-        assert result["safety_score"] < 100
-        assert result["bad_count"] >= 3  # "don't enter", "fake", "ban"
+        assert result["safety_score"] < 50
         assert len(result["details"]) > 0
-        assert any("ban" in word for word in result["details"])
 
-    def test_check_page_safety_with_false_positives(self, steamgifts_client):
-        """Test check_page_safety handles false positives correctly."""
-        # Contains "ban" but in context of "bank" or "banner"
-        tricky_html = """
-        <html>
-            <body>
-                <div class="giveaway">
-                    <h2>Bank Heist Simulator</h2>
-                    <p>Rob the bank and escape!</p>
-                    <p>See the banner above for details.</p>
-                </div>
-            </body>
-        </html>
-        """
+    def test_page_chrome_never_matches(self, steamgifts_client):
+        # The nav in the helper is full of trap words; without description or
+        # comments the page must still score 100.
+        result = steamgifts_client.check_page_safety(_giveaway_page())
 
-        result = steamgifts_client.check_page_safety(tricky_html)
+        assert result["verdict"] == "safe"
+        assert result["safety_score"] == 100
 
-        # Should be safe because "bank" and "banner" are in good words list
-        assert result["is_safe"] is True
-        assert result["good_count"] >= result["bad_count"]  # Good words cancel out
+    def test_word_boundaries_prevent_false_positives(self, steamgifts_client):
+        result = steamgifts_client.check_page_safety(
+            _giveaway_page("Bank Heist Simulator: rob the urban bank, dodge robots, see the banner!")
+        )
 
-    def test_check_page_safety_borderline(self, steamgifts_client):
-        """Test check_page_safety with borderline content."""
-        # Only one suspicious word - might be false positive
-        borderline_html = """
-        <html>
-            <body>
-                <div class="giveaway">
-                    <h2>Cool Game</h2>
-                    <p>This is totally not a bot giveaway!</p>
-                </div>
-            </body>
-        </html>
-        """
+        assert result["verdict"] == "safe"
+        assert result["safety_score"] == 100
 
-        result = steamgifts_client.check_page_safety(borderline_html)
+    def test_single_weak_word_is_borderline(self, steamgifts_client):
+        result = steamgifts_client.check_page_safety(
+            _giveaway_page("The screenshots on the store page are fake by the way")
+        )
 
-        # Should have detected "bot" and possibly "not" context
-        assert result["bad_count"] >= 1
-        # With only 1-2 bad words, should still be allowed (borderline)
-        assert result["safety_score"] >= 50
+        assert result["verdict"] == "borderline"
+        assert result["is_safe"] is False
+        assert 50 <= result["safety_score"] < 85
+
+    def test_warning_comments_lower_score(self, steamgifts_client):
+        result = steamgifts_client.check_page_safety(
+            _giveaway_page(
+                "Good luck!",
+                comments=(
+                    "do not enter, this is a bot trap",
+                    "don't enter — you will get banned",
+                    "trap giveaway, stay away",
+                ),
+            )
+        )
+
+        assert result["warning_comments"] == 3
+        assert result["verdict"] == "borderline"
+
+    def test_single_warning_comment_stays_safe(self, steamgifts_client):
+        result = steamgifts_client.check_page_safety(
+            _giveaway_page("Good luck!", comments=("nice giveaway", "do not enter, trap!"))
+        )
+
+        assert result["warning_comments"] == 1
+        assert result["verdict"] == "safe"
 
     @pytest.mark.asyncio
     async def test_check_giveaway_safety_success(self, steamgifts_client):

--- a/frontend/src/pages/Giveaways.tsx
+++ b/frontend/src/pages/Giveaways.tsx
@@ -541,6 +541,11 @@ function GiveawayCard({ giveaway, onEnter, onHide, onUnhide, onRemoveEntry, onCh
                 <Shield size={10} className="mr-1" />
                 Safe
               </Badge>
+            ) : (giveaway.safety_score ?? 0) >= 50 ? (
+              <Badge variant="warning" size="sm">
+                <ShieldAlert size={10} className="mr-1" />
+                Borderline
+              </Badge>
             ) : (
               <Badge variant="error" size="sm">
                 <ShieldAlert size={10} className="mr-1" />

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -207,7 +207,7 @@ function SettingsForm({ settings }: { settings: SettingsType }) {
         <div className="space-y-4">
           <Toggle
             label="Enable Trap Detection"
-            description="Check giveaways for warning words before auto-entering (e.g., 'don't enter', 'ban', 'fake')"
+            description="Scan each giveaway's description and comments for trap language (e.g., 'do not enter', 'bot trap', 'you will be banned') before auto-entering"
             checked={formData.safety_check_enabled ?? true}
             onChange={(checked) => handleChange('safety_check_enabled', checked)}
           />
@@ -219,8 +219,9 @@ function SettingsForm({ settings }: { settings: SettingsType }) {
           />
         </div>
         <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
-          Trap detection analyzes giveaway pages for warning signs that indicate scam or trap giveaways.
-          When enabled, unsafe giveaways will be skipped during auto-entry.
+          Unchecked giveaways are scored by a background sweep each cycle. Outright traps are
+          hidden; borderline scores (50&ndash;84) are skipped by auto-entry but stay visible with a
+          Borderline badge so you can review them and re-check manually.
         </p>
       </Card>
 


### PR DESCRIPTION
Detection now parses the giveaway description and comment thread out of the page and runs weighted word-boundary patterns on those texts only — page chrome and the old page-wide substring counting (with its GOOD_WORDS offset hack) are gone. Comments are a lower-weight signal: one warning comment can't flag a giveaway, a chorus drops it to borderline.

Verdicts are three-way. Safe (score >= 85) enters normally; borderline (50-84) is skipped without hiding so it stays reviewable; unsafe (< 50) is hidden on SteamGifts as before. A failing check now fails closed: the giveaway is skipped for the cycle instead of entered unchecked. is_safe False rows are excluded from eligibility (new "unsafe" reason) so skipped giveaways don't churn every cycle.

A new sweep step in the automation cycle scores up to 10 unchecked giveaways per cycle (soonest-expiring first) so verdicts exist before entry time; entry reuses stored verdicts younger than 24h (safety_checked_at, migration f1b8c5d3a9e2) instead of refetching.

Frontend: Borderline badge on cards, accurate safety settings copy.
Fixtures: two sanitized live giveaway pages + fetch_giveaway_page.py.