### PR TITLE
Revamp Analytics with per-day trend charts

### DIFF
--- a/backend/src/api/routers/analytics.py
+++ b/backend/src/api/routers/analytics.py
@@ -121,6 +121,69 @@ async def get_entry_summary(
 
 
 @router.get(
+    "/entries/trends",
+    response_model=dict[str, Any],
+    summary="Get daily entry trends",
+    description="Per-day entries, points and wins for trend charts.",
+)
+async def get_entry_trends(
+    giveaway_service: GiveawayServiceDep,
+    period: str = Query(
+        default="month",
+        pattern="^(week|month|year)$",
+        description="Time window: week (7d), month (30d), year (365d)",
+    ),
+) -> dict[str, Any]:
+    """
+    Get per-day entry/points/win series for the given window.
+
+    Days without activity are filled with zeros so charts get a
+    continuous series.
+
+    Example response:
+        {
+            "success": true,
+            "data": {
+                "period": "week",
+                "trends": [
+                    {"date": "2026-07-15", "entries": 12, "successful": 11,
+                     "failed": 1, "points_spent": 340, "wins": 0},
+                    ...
+                ]
+            }
+        }
+    """
+    days = {"week": 7, "month": 30, "year": 365}[period]
+    now = datetime.now(UTC)
+    since = (now - timedelta(days=days - 1)).replace(
+        hour=0, minute=0, second=0, microsecond=0, tzinfo=None
+    )
+
+    daily_entries = await giveaway_service.entry_repo.get_daily_stats(since)
+    daily_wins = await giveaway_service.giveaway_repo.get_daily_wins(since)
+
+    entries_by_day = {row["date"]: row for row in daily_entries}
+    wins_by_day = {row["date"]: row["wins"] for row in daily_wins}
+
+    trends = []
+    for offset in range(days):
+        day = (since + timedelta(days=offset)).date().isoformat()
+        entry_row = entries_by_day.get(day)
+        trends.append(
+            {
+                "date": day,
+                "entries": entry_row["entries"] if entry_row else 0,
+                "successful": entry_row["successful"] if entry_row else 0,
+                "failed": entry_row["failed"] if entry_row else 0,
+                "points_spent": entry_row["points_spent"] if entry_row else 0,
+                "wins": wins_by_day.get(day, 0),
+            }
+        )
+
+    return create_success_response(data={"period": period, "trends": trends})
+
+
+@router.get(
     "/giveaways/summary",
     response_model=dict[str, Any],
     summary="Get giveaway summary",

--- a/backend/src/repositories/entry.py
+++ b/backend/src/repositories/entry.py
@@ -8,7 +8,7 @@ entry performance.
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.entry import Entry
@@ -513,6 +513,42 @@ class EntryRepository(BaseRepository[Entry]):
                 "wishlist": row.wishlist or 0,
             },
         }
+
+    async def get_daily_stats(self, since: datetime) -> list[dict[str, Any]]:
+        """
+        Per-day entry aggregates since ``since`` (for trend charts).
+
+        Returns:
+            One dict per day that has entries, ascending by date:
+            ``{"date": "YYYY-MM-DD", "entries", "successful", "failed",
+            "points_spent"}`` — points counted on successful entries only.
+        """
+        day = func.date(self.model.created_at)
+        query = (
+            select(
+                day.label("day"),
+                func.count().label("entries"),
+                func.sum(case((self.model.status == "success", 1), else_=0)).label("successful"),
+                func.sum(case((self.model.status == "failed", 1), else_=0)).label("failed"),
+                func.sum(
+                    case((self.model.status == "success", self.model.points_spent), else_=0)
+                ).label("points_spent"),
+            )
+            .where(self.model.created_at >= since)
+            .group_by(day)
+            .order_by(day)
+        )
+        result = await self.session.execute(query)
+        return [
+            {
+                "date": row.day,
+                "entries": row.entries,
+                "successful": int(row.successful or 0),
+                "failed": int(row.failed or 0),
+                "points_spent": int(row.points_spent or 0),
+            }
+            for row in result.all()
+        ]
 
     async def get_recent_failures(self, limit: int = 10) -> list[Entry]:
         """

--- a/backend/src/repositories/giveaway.py
+++ b/backend/src/repositories/giveaway.py
@@ -8,7 +8,7 @@ giveaway visibility.
 from datetime import datetime, timedelta
 from typing import Any
 
-from sqlalchemy import ColumnElement, and_, or_, select, update
+from sqlalchemy import ColumnElement, and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.time import utcnow
@@ -807,6 +807,30 @@ class GiveawayRepository(BaseRepository[Giveaway]):
         )
         result = await self.session.execute(query)
         return result.scalar() or 0
+
+    async def get_daily_wins(self, since: datetime) -> list[dict[str, Any]]:
+        """
+        Per-day win counts since ``since`` (for trend charts).
+
+        Returns:
+            One dict per day that has wins, ascending:
+            ``{"date": "YYYY-MM-DD", "wins": n}``.
+        """
+        day = func.date(self.model.won_at)
+        query = (
+            select(day.label("day"), func.count().label("wins"))
+            .where(
+                and_(
+                    self.model.is_won == True,  # noqa: E712
+                    self.model.won_at.isnot(None),
+                    self.model.won_at >= since,
+                )
+            )
+            .group_by(day)
+            .order_by(day)
+        )
+        result = await self.session.execute(query)
+        return [{"date": row.day, "wins": row.wins} for row in result.all()]
 
     async def count_won_since(self, since: datetime) -> int:
         """

--- a/backend/tests/unit/test_api_routers_analytics.py
+++ b/backend/tests/unit/test_api_routers_analytics.py
@@ -99,6 +99,40 @@ async def test_get_entry_summary():
 
 
 @pytest.mark.asyncio
+async def test_get_entry_trends_fills_missing_days():
+    """Trends return a continuous zero-filled daily series with wins merged in."""
+    from datetime import UTC, datetime, timedelta
+
+    from api.routers.analytics import get_entry_trends
+
+    today = datetime.now(UTC).date().isoformat()
+    yesterday = (datetime.now(UTC) - timedelta(days=1)).date().isoformat()
+
+    mock_giveaway_service = AsyncMock()
+    mock_giveaway_service.entry_repo.get_daily_stats.return_value = [
+        {"date": yesterday, "entries": 3, "successful": 2, "failed": 1, "points_spent": 90},
+    ]
+    mock_giveaway_service.giveaway_repo.get_daily_wins.return_value = [
+        {"date": today, "wins": 1},
+    ]
+
+    result = await get_entry_trends(giveaway_service=mock_giveaway_service, period="week")
+
+    assert result["success"] is True
+    trends = result["data"]["trends"]
+    assert len(trends) == 7  # every day present, gaps zero-filled
+    by_date = {t["date"]: t for t in trends}
+    assert by_date[yesterday]["entries"] == 3
+    assert by_date[yesterday]["points_spent"] == 90
+    assert by_date[today]["wins"] == 1
+    assert by_date[today]["entries"] == 0
+    # A day with no data at all is all zeros
+    zero_days = [t for t in trends if t["date"] not in (today, yesterday)]
+    assert all(t["entries"] == 0 and t["wins"] == 0 for t in zero_days)
+    assert trends[-1]["date"] == today  # ascending, ends today
+
+
+@pytest.mark.asyncio
 async def test_get_giveaway_summary():
     """Test GET /analytics/giveaways/summary endpoint."""
     mock_giveaway_service = AsyncMock()

--- a/backend/tests/unit/test_repositories_entry.py
+++ b/backend/tests/unit/test_repositories_entry.py
@@ -112,6 +112,43 @@ async def test_search_combines_filters_joins_giveaway_and_counts(test_db, sample
 
 
 @pytest.mark.asyncio
+async def test_get_daily_stats(test_db, sample_giveaway):
+    """get_daily_stats groups by day, counts statuses, sums success points."""
+    async with test_db() as session:
+        repo = EntryRepository(session)
+
+        await repo.create(
+            giveaway_id=sample_giveaway, points_spent=50, entry_type="auto", status="success"
+        )
+        await repo.create(
+            giveaway_id=sample_giveaway, points_spent=30, entry_type="auto", status="success"
+        )
+        failed = await repo.create(
+            giveaway_id=sample_giveaway, points_spent=0, entry_type="auto", status="failed"
+        )
+        old = await repo.create(
+            giveaway_id=sample_giveaway, points_spent=99, entry_type="auto", status="success"
+        )
+        old.created_at = utcnow() - timedelta(days=3)
+        await session.commit()
+
+        rows = await repo.get_daily_stats(since=utcnow() - timedelta(days=7))
+
+        assert len(rows) == 2  # today + three days ago
+        today = rows[-1]
+        assert today["entries"] == 3
+        assert today["successful"] == 2
+        assert today["failed"] == 1
+        assert today["points_spent"] == 80  # success points only
+        assert rows[0]["points_spent"] == 99
+        assert failed.status == "failed"
+
+        # Window excludes the old day
+        rows = await repo.get_daily_stats(since=utcnow() - timedelta(days=1))
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
 async def test_get_recent(test_db, sample_giveaway):
     """Test getting recent entries ordered by creation time."""
     async with test_db() as session:

--- a/backend/tests/unit/test_repositories_giveaway.py
+++ b/backend/tests/unit/test_repositories_giveaway.py
@@ -964,3 +964,36 @@ async def test_create_or_update_by_code_updates_existing(test_db):
         # Verify only one record exists
         all_giveaways = await repo.get_all()
         assert len(all_giveaways) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_daily_wins(test_db):
+    """get_daily_wins groups won giveaways by day within the window."""
+    async with test_db() as session:
+        repo = GiveawayRepository(session)
+
+        now = utcnow()
+        await repo.create(
+            code="WIN1", game_name="A", price=10, url="http://x/1",
+            is_won=True, won_at=now,
+        )
+        await repo.create(
+            code="WIN2", game_name="B", price=10, url="http://x/2",
+            is_won=True, won_at=now,
+        )
+        await repo.create(
+            code="WIN3", game_name="C", price=10, url="http://x/3",
+            is_won=True, won_at=now - timedelta(days=2),
+        )
+        await repo.create(
+            code="OLDWIN", game_name="D", price=10, url="http://x/4",
+            is_won=True, won_at=now - timedelta(days=30),
+        )
+        await repo.create(code="NOWIN", game_name="E", price=10, url="http://x/5")
+        await session.commit()
+
+        rows = await repo.get_daily_wins(since=now - timedelta(days=7))
+
+        assert len(rows) == 2  # two days with wins inside the window
+        assert rows[-1]["wins"] == 2  # today, ascending order
+        assert rows[0]["wins"] == 1

--- a/frontend/e2e/analytics.spec.ts
+++ b/frontend/e2e/analytics.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { mockApi } from './mocks';
+
+test.describe('Analytics page', () => {
+  test('renders trend charts with legend and table view', async ({ page }) => {
+    await mockApi(page);
+    await page.goto('/analytics');
+
+    await expect(page.getByRole('heading', { name: 'Analytics' })).toBeVisible();
+    await expect(page.getByText('Entries per day')).toBeVisible();
+    await expect(page.getByText('Points spent per day')).toBeVisible();
+    await expect(page.getByText('Wins per day')).toBeVisible();
+
+    // Legend carries series identity for the two-series chart
+    const legend = page.locator('.recharts-legend-wrapper');
+    await expect(legend.getByText('Successful')).toBeVisible();
+    await expect(legend.getByText('Failed / skipped')).toBeVisible();
+
+    // Charts actually painted bars/areas into the SVGs
+    const barCount = await page.locator('.recharts-bar-rectangle').count();
+    expect(barCount).toBeGreaterThan(10);
+
+    // Accessible table alternative exists and opens
+    await page.getByText('View trend data as table').click();
+    await expect(page.getByRole('columnheader', { name: 'Points' })).toBeVisible();
+
+    await page.screenshot({ path: 'test-results/analytics-light.png', fullPage: true });
+
+    // Dark mode render
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.evaluate(() => document.documentElement.classList.add('dark'));
+    await page.screenshot({ path: 'test-results/analytics-dark.png', fullPage: true });
+  });
+});

--- a/frontend/e2e/mocks.ts
+++ b/frontend/e2e/mocks.ts
@@ -191,7 +191,20 @@ export async function mockApi(page: Page): Promise<ApiCall[]> {
       return route.fulfill(ok({ total: 200, games: 180, dlc: 15, bundles: 5, stale_count: 3 }));
     }
     if (path.startsWith('/api/v1/analytics/entries/trends')) {
-      return route.fulfill(ok({ period: 'week', trends: [] }));
+      const trends = Array.from({ length: 30 }, (_, i) => {
+        const d = new Date(Date.now() - (29 - i) * 86_400_000);
+        const successful = (i * 7) % 11;
+        const failed = i % 3 === 0 ? 1 : 0;
+        return {
+          date: d.toISOString().slice(0, 10),
+          entries: successful + failed,
+          successful,
+          failed,
+          points_spent: successful * 27,
+          wins: i % 9 === 0 ? 1 : 0,
+        };
+      });
+      return route.fulfill(ok({ period: 'month', trends }));
     }
 
     // --- System logs (Dashboard activity feed / Logs page) ---

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^19.2.7",
         "react-icons": "^5.7.0",
         "react-router": "^7.18.1",
+        "recharts": "^3.10.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -1345,6 +1346,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -1613,7 +1640,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/forms": {
@@ -2046,6 +2078,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2093,6 +2188,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.63.0",
@@ -2770,6 +2871,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -2817,6 +3039,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -2894,6 +3122,16 @@
       "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -3193,6 +3431,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -3408,6 +3652,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3426,6 +3680,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -4358,9 +4621,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-router": {
       "version": "7.18.1",
@@ -4384,6 +4669,36 @@
         }
       }
     },
+    "node_modules/recharts": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.0.tgz",
+      "integrity": "sha512-wulMvfncpIlmu2uFtRU/mE5/+NiVtASXkw2KdwJTdHs3WsASX0WxZlX+rpKgyn5BDbIhkPtCpUKkB9XNK5KE0w==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -4398,6 +4713,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4407,6 +4737,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.1.5",
@@ -4587,6 +4923,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4799,6 +5141,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.2.7",
     "react-icons": "^5.7.0",
     "react-router": "^7.18.1",
+    "recharts": "^3.10.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/frontend/src/components/analytics/TrendCharts.tsx
+++ b/frontend/src/components/analytics/TrendCharts.tsx
@@ -1,0 +1,216 @@
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { Card, CardSkeleton } from '@/components/common';
+import type { TrendDataPoint } from '@/hooks';
+
+/**
+ * Per-day trend charts for the Analytics page.
+ *
+ * Colors come from the validated chart palette in index.css. The entries
+ * chart uses the "emphasis" form: successful entries carry the accent hue,
+ * failed ones the de-emphasis gray, with a legend carrying identity.
+ */
+
+const formatDay = (iso: string) =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+
+// Tooltip labels arrive typed as ReactNode; only format the string case
+const formatDayLabel = (label: React.ReactNode) =>
+  typeof label === 'string' ? formatDay(label) : label;
+
+const axisTick = { fill: 'var(--chart-ink-muted)', fontSize: 12 } as const;
+
+const tooltipStyle = {
+  backgroundColor: 'var(--chart-surface)',
+  border: '1px solid var(--chart-grid)',
+  borderRadius: '8px',
+  fontSize: '12px',
+} as const;
+
+const tooltipLabelStyle = { color: 'var(--chart-ink-muted)' } as const;
+
+function legendText(value: string) {
+  return <span className="text-sm text-gray-600 dark:text-gray-300">{value}</span>;
+}
+
+interface ChartFrameProps {
+  title: string;
+  children: React.ReactElement;
+}
+
+function ChartFrame({ title, children }: ChartFrameProps) {
+  return (
+    <Card>
+      <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">{title}</h3>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          {children}
+        </ResponsiveContainer>
+      </div>
+    </Card>
+  );
+}
+
+interface TrendChartsProps {
+  trends: TrendDataPoint[] | undefined;
+  isLoading: boolean;
+}
+
+export function TrendCharts({ trends, isLoading }: TrendChartsProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <CardSkeleton />
+        <CardSkeleton />
+      </div>
+    );
+  }
+
+  if (!trends || trends.length === 0) {
+    return null;
+  }
+
+  const hasWins = trends.some((t) => t.wins > 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <ChartFrame title="Entries per day">
+          <BarChart data={trends} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke="var(--chart-grid)" />
+            <XAxis
+              dataKey="date"
+              tickFormatter={formatDay}
+              tick={axisTick}
+              tickLine={false}
+              axisLine={{ stroke: 'var(--chart-grid)' }}
+              minTickGap={24}
+            />
+            <YAxis tick={axisTick} tickLine={false} axisLine={false} allowDecimals={false} />
+            <Tooltip
+              labelFormatter={formatDayLabel}
+              contentStyle={tooltipStyle}
+              labelStyle={tooltipLabelStyle}
+              cursor={{ fill: 'var(--chart-grid)', fillOpacity: 0.35 }}
+            />
+            <Legend formatter={legendText} iconSize={10} />
+            <Bar
+              dataKey="successful"
+              name="Successful"
+              stackId="entries"
+              fill="var(--chart-series-1)"
+              stroke="var(--chart-surface)"
+              strokeWidth={1}
+            />
+            <Bar
+              dataKey="failed"
+              name="Failed / skipped"
+              stackId="entries"
+              fill="var(--chart-emphasis)"
+              stroke="var(--chart-surface)"
+              strokeWidth={1}
+              radius={[4, 4, 0, 0]}
+            />
+          </BarChart>
+        </ChartFrame>
+
+        <ChartFrame title="Points spent per day">
+          <AreaChart data={trends} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke="var(--chart-grid)" />
+            <XAxis
+              dataKey="date"
+              tickFormatter={formatDay}
+              tick={axisTick}
+              tickLine={false}
+              axisLine={{ stroke: 'var(--chart-grid)' }}
+              minTickGap={24}
+            />
+            <YAxis tick={axisTick} tickLine={false} axisLine={false} allowDecimals={false} />
+            <Tooltip
+              labelFormatter={formatDayLabel}
+              formatter={(value) => [`${value}P`, 'Points spent']}
+              contentStyle={tooltipStyle}
+              labelStyle={tooltipLabelStyle}
+            />
+            <Area
+              type="monotone"
+              dataKey="points_spent"
+              stroke="var(--chart-series-1)"
+              strokeWidth={2}
+              fill="var(--chart-series-1)"
+              fillOpacity={0.15}
+            />
+          </AreaChart>
+        </ChartFrame>
+      </div>
+
+      {hasWins && (
+        <ChartFrame title="Wins per day">
+          <BarChart data={trends} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid vertical={false} stroke="var(--chart-grid)" />
+            <XAxis
+              dataKey="date"
+              tickFormatter={formatDay}
+              tick={axisTick}
+              tickLine={false}
+              axisLine={{ stroke: 'var(--chart-grid)' }}
+              minTickGap={24}
+            />
+            <YAxis tick={axisTick} tickLine={false} axisLine={false} allowDecimals={false} />
+            <Tooltip
+              labelFormatter={formatDayLabel}
+              formatter={(value) => [value, 'Wins']}
+              contentStyle={tooltipStyle}
+              labelStyle={tooltipLabelStyle}
+              cursor={{ fill: 'var(--chart-grid)', fillOpacity: 0.35 }}
+            />
+            <Bar dataKey="wins" name="Wins" fill="var(--chart-series-2)" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ChartFrame>
+      )}
+
+      {/* Accessible alternative: the same data as a table */}
+      <details className="text-sm">
+        <summary className="cursor-pointer text-gray-500 dark:text-gray-400 select-none">
+          View trend data as table
+        </summary>
+        <div className="mt-2 overflow-x-auto">
+          <table className="min-w-full text-left text-gray-700 dark:text-gray-300">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-700 text-xs uppercase text-gray-500">
+                <th className="py-1 pr-4">Date</th>
+                <th className="py-1 pr-4">Entries</th>
+                <th className="py-1 pr-4">Successful</th>
+                <th className="py-1 pr-4">Failed</th>
+                <th className="py-1 pr-4">Points</th>
+                <th className="py-1">Wins</th>
+              </tr>
+            </thead>
+            <tbody className="tabular-nums">
+              {trends.map((t) => (
+                <tr key={t.date} className="border-b border-gray-100 dark:border-gray-800">
+                  <td className="py-1 pr-4">{t.date}</td>
+                  <td className="py-1 pr-4">{t.entries}</td>
+                  <td className="py-1 pr-4">{t.successful}</td>
+                  <td className="py-1 pr-4">{t.failed}</td>
+                  <td className="py-1 pr-4">{t.points_spent}</td>
+                  <td className="py-1">{t.wins}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useAnalytics.test.tsx
+++ b/frontend/src/hooks/useAnalytics.test.tsx
@@ -253,13 +253,13 @@ describe('useAnalytics', () => {
   describe('useEntryTrends hook', () => {
     it('should fetch entry trends successfully', async () => {
       const mockTrends = [
-        { date: '2024-01-01', entries: 10, points_spent: 50 },
-        { date: '2024-01-02', entries: 15, points_spent: 75 },
+        { date: '2024-01-01', entries: 10, successful: 9, failed: 1, points_spent: 50, wins: 0 },
+        { date: '2024-01-02', entries: 15, successful: 15, failed: 0, points_spent: 75, wins: 1 },
       ];
 
       mockApi.get.mockResolvedValueOnce({
         success: true,
-        data: mockTrends,
+        data: { period: 'month', trends: mockTrends },
       });
 
       const { result } = renderHook(() => useEntryTrends('month'), {

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -164,23 +164,32 @@ export function useGameStats() {
 export interface TrendDataPoint {
   date: string;
   entries: number;
+  successful: number;
+  failed: number;
   points_spent: number;
+  wins: number;
+}
+
+/** Backend response for entries/trends */
+interface TrendsResponse {
+  period: string;
+  trends: TrendDataPoint[];
 }
 
 /**
- * Fetch entry trends over time
+ * Fetch per-day entry/points/win trends
  */
 export function useEntryTrends(period: 'week' | 'month' | 'year' = 'month') {
   return useQuery({
     queryKey: [...analyticsKeys.entries, 'trends', period],
     queryFn: async () => {
-      const response = await api.get<TrendDataPoint[]>(
+      const response = await api.get<TrendsResponse>(
         `/api/v1/analytics/entries/trends?period=${period}`
       );
       if (!response.success) {
         throw new Error(response.error || 'Failed to fetch entry trends');
       }
-      return response.data;
+      return response.data?.trends ?? [];
     },
   });
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,4 +63,22 @@
   html {
     transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
   }
+
+  /* Chart palette (validated per-mode; see Analytics page) */
+  :root {
+    --chart-series-1: #2a78d6; /* accent series (blue) */
+    --chart-series-2: #008300; /* wins (green) */
+    --chart-emphasis: #898781; /* de-emphasis gray for context series */
+    --chart-grid: #e1e0d9;
+    --chart-ink-muted: #898781;
+    --chart-surface: #ffffff; /* matches the light card surface */
+  }
+  .dark {
+    --chart-series-1: #3987e5;
+    --chart-series-2: #008300;
+    --chart-emphasis: #898781;
+    --chart-grid: #2c3350;
+    --chart-ink-muted: #898781;
+    --chart-surface: #16213e; /* matches --color-surface-dark cards */
+  }
 }

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,7 +1,17 @@
 import { useState } from 'react';
-import { TrendingUp, Target, Gift, Gamepad2, AlertCircle, CheckCircle, XCircle, Zap, type LucideIcon } from 'lucide-react';
+import { TrendingUp, Target, Gift, Gamepad2, AlertCircle, CheckCircle, XCircle, Zap, LineChart, type LucideIcon } from 'lucide-react';
 import { Card, Badge, CardSkeleton } from '@/components/common';
-import { useEntryStats, useGiveawayStats, useGameStats, type TimeRangeFilter } from '@/hooks';
+import { useEntryStats, useEntryTrends, useGiveawayStats, useGameStats, type TimeRangeFilter } from '@/hooks';
+import { TrendCharts } from '@/components/analytics/TrendCharts';
+
+/** The trends endpoint covers week/month/year; map the page periods onto it. */
+const TREND_PERIODS = {
+  day: 'week',
+  week: 'week',
+  month: 'month',
+  year: 'year',
+  all: 'year',
+} as const;
 
 /**
  * Analytics page
@@ -13,6 +23,9 @@ export function Analytics() {
   const { data: entryStats, isLoading: entriesLoading, error: entriesError } = useEntryStats(timeRange);
   const { data: giveawayStats, isLoading: giveawaysLoading, error: giveawaysError } = useGiveawayStats(timeRange);
   const { data: gameStats, isLoading: gamesLoading, error: gamesError } = useGameStats();
+  const { data: trends, isLoading: trendsLoading } = useEntryTrends(
+    TREND_PERIODS[timeRange.period ?? 'month']
+  );
 
   const isLoading = entriesLoading || giveawaysLoading || gamesLoading;
   const hasError = entriesError || giveawaysError || gamesError;
@@ -74,6 +87,15 @@ export function Analytics() {
           </PeriodButton>
         </div>
       </div>
+
+      {/* Trends */}
+      <section>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+          <LineChart size={20} />
+          Trends
+        </h2>
+        <TrendCharts trends={trends} isLoading={trendsLoading} />
+      </section>
 
       {/* Entry Statistics */}
       <section>


### PR DESCRIPTION
New GET /analytics/entries/trends endpoint aggregates entries per day in SQL (count, successful, failed, success-only points) merged with per-day win counts, zero-filling gaps so charts get a continuous series over a week/month/year window — the useEntryTrends hook that previously called a nonexistent route is now wired to it.

The Analytics page leads with a Trends section (recharts): successful vs failed entries as stacked bars (accent + de-emphasis gray, legend), points spent as an area, and wins as bars when any exist, followed by the existing stat tiles. Chart colors are CSS custom properties with CVD-validated light/dark values matched to the app surfaces, and the data is also available as a collapsible table. Covered by a Playwright spec that renders the page against mocked trends in both themes.