### PR TITLE
Keep Settings inline at the end of the sidebar list

### DIFF
--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -43,7 +43,7 @@ describe('Sidebar', () => {
     expect(listItems).toHaveLength(10);
   });
 
-  it('should pin Settings as the last link, in the bottom section', () => {
+  it('should render Settings as the last link', () => {
     render(<Sidebar />);
 
     const links = screen.getAllByRole('link');

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -23,7 +23,8 @@ interface NavItem {
   end?: boolean;
 }
 
-// Navigation items configuration
+// Navigation items configuration. Settings goes last: pinning it to the
+// column bottom scrolled it off-screen on pages taller than the viewport.
 const navItems: NavItem[] = [
   { path: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { path: '/giveaways', label: 'Giveaways', icon: Gift, end: true },
@@ -34,10 +35,8 @@ const navItems: NavItem[] = [
   { path: '/history', label: 'History', icon: History },
   { path: '/analytics', label: 'Analytics', icon: BarChart3 },
   { path: '/logs', label: 'Logs', icon: FileText },
+  { path: '/settings', label: 'Settings', icon: Settings },
 ];
-
-// Pinned to the bottom of the column, below the scrollable main nav
-const bottomNavItems: NavItem[] = [{ path: '/settings', label: 'Settings', icon: Settings }];
 
 function NavList({ items }: { items: NavItem[] }) {
   return (
@@ -70,12 +69,9 @@ function NavList({ items }: { items: NavItem[] }) {
  */
 export function Sidebar() {
   return (
-    <aside className="w-64 border-r border-gray-200 dark:border-gray-700 bg-surface-light dark:bg-surface-dark min-h-[calc(100vh-4rem)] flex flex-col">
-      <nav className="p-4 flex flex-col flex-1">
+    <aside className="w-64 border-r border-gray-200 dark:border-gray-700 bg-surface-light dark:bg-surface-dark min-h-[calc(100vh-4rem)]">
+      <nav className="p-4">
         <NavList items={navItems} />
-        <div className="mt-auto pt-4 border-t border-gray-200 dark:border-gray-700">
-          <NavList items={bottomNavItems} />
-        </div>
       </nav>
     </aside>
   );


### PR DESCRIPTION
Pinning it to the column bottom pushed it below the fold on pages taller than the viewport (the sidebar grows with the page), forcing a scroll to reach it. Back to a single list with Settings last.